### PR TITLE
I've created new advisor files for Phase 1 Section 3 & 3a.

### DIFF
--- a/advisor/ineligible_vow_discharge_type.md
+++ b/advisor/ineligible_vow_discharge_type.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Own Service (VOW Act): Ineligible - Discharge Not Expected to be Honorable
+---
+
+## Own Service (VOW Act): Ineligible - Discharge Not Expected to be Honorable
+
+Veteran's preference requires eventual discharge or release under honorable conditions. If your VOW Act certification does not indicate an expected honorable discharge, you may not proceed with a claim for preference at this time under the VOW Act. (See OPM Vet Guide, 'A word about the VOW Act').
+
+*   [Return to Advisor Start](./start.md)

--- a/advisor/ineligible_vow_retiredmajor_notdisabled.md
+++ b/advisor/ineligible_vow_retiredmajor_notdisabled.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Own Service (VOW Act): Ineligible - Retired Officer Not Disabled
+---
+
+## Own Service (VOW Act): Ineligible - Retired Officer Not Disabled
+
+Military retirees at the rank of Major, Lieutenant Commander, or higher are not eligible for preference unless they are disabled veterans. (OPM Vet Guide, 'Types of Preference'). Based on your responses, you may not be eligible for veteran's preference if you retire at this rank without a disability.
+
+*   [Return to Advisor Start](./start.md)

--- a/advisor/ownservice_vow_checkretired.md
+++ b/advisor/ownservice_vow_checkretired.md
@@ -1,0 +1,14 @@
+---
+layout: default
+title: Own Service (VOW Act): Check Retiree Status
+---
+
+## Own Service (VOW Act): Check Retiree Status
+
+Regarding your upcoming discharge/release: Are you a military retiree (or will you be upon discharge/release) at the rank of Major, Lieutenant Commander, or higher? (This generally does not apply to Reservists who will not begin drawing military retired pay until age 60. See OPM Vet Guide, 'Types of Preference' and Appendix C for rank equivalents.)
+
+*   [Yes, I expect to be a retiree at Major/Lt. Commander or higher.](./ownservice_vow_retiredmajor_isdisabled.md)
+*   [No, I do not expect to be a retiree at that rank, OR I am a Reservist not anticipating drawing retired pay until age 60.](./ownservice_vow_honorableconditions.md)
+
+---
+[Return to Advisor Start](./start.md)

--- a/advisor/ownservice_vow_honorableconditions.md
+++ b/advisor/ownservice_vow_honorableconditions.md
@@ -1,0 +1,14 @@
+---
+layout: default
+title: Own Service (VOW Act): Expected Character of Service
+---
+
+## Own Service (VOW Act): Expected Character of Service
+
+To receive preference, discharge must be under honorable conditions. Does your VOW Act certification state you are expected to be discharged/released under honorable conditions (i.e., an Honorable or General discharge)? (See OPM Vet Guide, 'A word about the VOW Act' regarding certification requirements).
+
+*   [Yes, my certification indicates an expected Honorable or General discharge.](./ownservice_checkdisability_intro.md)
+*   [No, my certification indicates otherwise, or I cannot obtain such certification.](./ineligible_vow_discharge_type.md)
+
+---
+[Return to Advisor Start](./start.md)

--- a/advisor/ownservice_vow_retiredmajor_isdisabled.md
+++ b/advisor/ownservice_vow_retiredmajor_isdisabled.md
@@ -1,0 +1,14 @@
+---
+layout: default
+title: Own Service (VOW Act): Retired Major/Lt. Cmdr+ - Check Disability
+---
+
+## Own Service (VOW Act): Retired Major/Lt. Cmdr+ - Check Disability
+
+Military retirees at the rank of Major, Lieutenant Commander, or higher are generally not eligible for preference unless they are disabled veterans. (OPM Vet Guide, 'Types of Preference'). Do you currently have a service-connected disability, or do you anticipate being recognized as a disabled veteran upon discharge?
+
+*   [Yes, I am (or expect to be) a disabled veteran.](./ownservice_vow_honorableconditions.md)
+*   [No, I am not (and do not expect to be) a disabled veteran.](./ineligible_vow_retiredmajor_notdisabled.md)
+
+---
+[Return to Advisor Start](./start.md)


### PR DESCRIPTION
This update adds 11 new markdown files to the /advisor/ directory as part of implementing Phase 1, Section 3 ("Own Service" - Discharged Path) and Section 3a ("Own Service" - VOW Act Path) of the Veteran's Preference Advisor.

Here are the files I created:

Section 3 (Discharged Path):
- ownservice_discharged_checkretired.md
- ownservice_discharged_retiredmajor_isdisabled.md
- ineligible_retiredmajor_notdisabled.md
- ownservice_discharged_honorableconditions.md
- ineligible_discharge_type.md
- ownservice_discharged_checkdd214_discharge.md

Section 3a (VOW Act Path):
- ownservice_vow_checkretired.md
- ownservice_vow_retiredmajor_isdisabled.md
- ineligible_vow_retiredmajor_notdisabled.md
- ownservice_vow_honorableconditions.md
- ineligible_vow_discharge_type.md

Each file includes the specified title, content, questions, choices (as links to other pages), a link back to the advisor start page, and uses the default layout, just as we planned.