### PR TITLE
I've completed the QA Phase 5 checks and implemented the necessary up…

### DIFF
--- a/advisor/ineligible_ownservice_status.md
+++ b/advisor/ineligible_ownservice_status.md
@@ -1,8 +1,9 @@
 ---
 layout: default
-title: Veteran's Preference Advisor - Ineligible Service Status
+title: Ineligible Based on Current Service Status
 ---
 
-To claim preference based on your own service, you generally need to have been discharged/released from active duty or be an active duty member covered by the VOW Act (expected discharge within 120 days with certification). (See OPM Vet Guide, 'A word about the VOW Act'). If neither of these applies, you may not be eligible for preference at this time through this path.
+Based on your responses, you do not currently meet the preliminary requirements for veteran's preference. Generally, you must be discharged or released from active duty under honorable conditions to be eligible. If you are still on active duty, you may be eligible under the VOW Act if you are within 120 days of discharge and can provide a certification. <!-- TODO: Add link to VOW Act info or back to VOW questions if applicable --> For more information, please review the OPM Vet Guide [Appendix A - Definitions of Terms and Categories, Page 31].
 
+*   [I made a mistake in my previous answers, take me back.](./ownservice_intro.md)
 *   [Return to Advisor Start](./start.md)


### PR DESCRIPTION
…dates.

This commit includes the following changes based on QA Phase 5 verification:

1.  **Verified `advisor/start.md` links:** I confirmed all links use standardized filenames.
2.  **Updated `advisor/ineligible_ownservice_status.md`:**
    *   I corrected the title to "Ineligible Based on Current Service Status".
    *   I updated the content to align with Plan Document specifications, including a more specific OPM Vet Guide citation and a TODO for a VOW Act link.
    *   I added the missing choice: "[I made a mistake in my previous answers, take me back.](./ownservice_intro.md)".
3.  **Verified logic in `advisor/ownservice_discharged_retiredmajor_isdisabled.md`:** I confirmed the correct link for the "Yes, I am a disabled veteran." choice.
4.  **Verified logic in `advisor/ownservice_vow_honorableconditions.md`:** I confirmed the correct link for the VOW Act honorable conditions choice. I noted the absence of a VOW reminder on the target page (potential Phase 2 item).
5.  **Verified link in `advisor/ownservice_checkdisability_intro.md`:** I confirmed the link to the future Phase 2 file `advisor/ownservice_disability_details.md`.
6.  **Verified link and content for `advisor/ownservice_discharged_checkfirst_solesurvivor.md`:** I confirmed the link to the future Phase 4 file `advisor/ownservice_ssp_eligible.md` and that the content aligns with the adjusted flow for SSP.
7.  **Verified link in `advisor/ownservice_tp_24month_exceptions.md`:** I confirmed the link to the future Phase 2 file `advisor/ownservice_disability_details.md`.
8.  **Disclaimer Accessibility:** A key finding from QA Phase 5 is that no global, layout-based disclaimer was found. This means the requirement for a disclaimer to be "visible or easily accessible from all advisor pages" is likely not met. I reported this, but it was not changed in this commit as the disclaimer text and placement require further specification.

The only file I modified in this commit is `advisor/ineligible_ownservice_status.md`.