### PR TITLE
Creating initial Markdown files for Phase 2 disability path

### DIFF
--- a/advisor/ownservice_cps_details.md
+++ b/advisor/ownservice_cps_details.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Own Service: 10-Point Preference (CPS) - 30%+ Disability
+---
+
+You indicated a service-connected disability rating of 30% or more. [cite_start]This generally qualifies you for 10-point Veteran's Preference (CPS), provided your discharge was (or will be, if VOW Act applies) under honorable conditions and all other general eligibility requirements are met. [cite_start]For disabled veterans, active duty includes training service in the Reserves or National Guard. [cite_start]Remember to complete the SF-15 form.
+
+*   [Confirm, proceed to eligibility summary.](./eligible_cps_10point.md)
+*   [I made a mistake, review disability/Purple Heart options.](./ownservice_disability_details.md)
+*   [Return to Advisor Start](./start.md)

--- a/advisor/ownservice_disability_details.md
+++ b/advisor/ownservice_disability_details.md
@@ -1,0 +1,13 @@
+---
+layout: default
+title: Own Service: Disability or Purple Heart Details
+---
+
+You indicated you have a service-connected disability or received a Purple Heart. To determine the type of 10-point preference, please select the option that best describes your situation. [cite_start](Remember, if you are claiming 10-point preference, you will typically need to complete an SF-15 form and provide supporting documentation. )
+
+*   ["I received a Purple Heart."](./ownservice_xp_purpleheart.md)
+*   ["I have a service-connected disability rating of 30% or more from the VA or my branch of service."](./ownservice_cps_details.md)
+*   ["I have a service-connected disability rating of 10% or 20% from the VA or my branch of service."](./ownservice_cp_details.md)
+*   ["I have a service-connected disability (rated less than 10% or not yet rated but recognized) OR I am receiving compensation, disability retirement benefits, or pension from the military or VA due to a service-connected disability, but I don't fit the 10-30%+ categories above."](./ownservice_xp_generaldisability_details.md)
+*   ["I'm not sure about the percentage or type."](./ownservice_disability_clarify_sf15.md)
+*   "[Return to Advisor Start](./start.md)"

--- a/advisor/ownservice_xp_purpleheart.md
+++ b/advisor/ownservice_xp_purpleheart.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Own Service: 10-Point Preference (XP) - Purple Heart
+---
+
+You indicated you received a Purple Heart. [cite_start]Receipt of a Purple Heart qualifies you for 10-point Veteran's Preference (XP), provided your discharge was (or will be, if VOW Act applies) under honorable conditions and all other general eligibility requirements are met. [cite_start]For disabled veterans, active duty includes training service in the Reserves or National Guard.
+
+*   [Confirm, proceed to eligibility summary.](./eligible_xp_10point.md)
+*   [I made a mistake, review disability/Purple Heart options.](./ownservice_disability_details.md)
+*   [Return to Advisor Start](./start.md)


### PR DESCRIPTION
This commit adds the following files as outlined in the plan:

- advisor/ownservice_disability_details.md: Gathers specific disability or Purple Heart details.
- advisor/ownservice_xp_purpleheart.md: Confirms potential XP preference for Purple Heart recipients.
- advisor/ownservice_cps_details.md: Confirms potential CPS preference for veterans with 30%+ disability.

These files include titles, layout specifications, content, citations, and navigation links as per the plan.