### PR TITLE
Here is the rewritten message:

### DIFF
--- a/advisor/ownservice_cp_details.md
+++ b/advisor/ownservice_cp_details.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Own Service: 10-Point Preference (CP) - 10-20% Disability
+---
+
+You indicated a service-connected disability rating of 10% or 20%. [cite_start]This generally qualifies you for 10-point Veteran's Preference (CP), provided your discharge was (or will be, if VOW Act applies) under honorable conditions and all other general eligibility requirements are met. [cite_start]For disabled veterans, active duty includes training service in the Reserves or National Guard. [cite_start]Remember to complete the SF-15 form.
+
+*   [Confirm, proceed to eligibility summary.](./eligible_cp_10point.md)
+*   [I made a mistake, review disability/Purple Heart options.](./ownservice_disability_details.md)
+*   [Return to Advisor Start](./start.md)

--- a/advisor/ownservice_disability_clarify_sf15.md
+++ b/advisor/ownservice_disability_clarify_sf15.md
@@ -1,0 +1,9 @@
+---
+layout: default
+title: Own Service: Disability Preference - Clarification Needed
+---
+
+Understanding your specific disability rating and type is important for determining 10-point preference. Please review your documentation from the Department of Veterans Affairs (VA) or your branch of service. [cite_start]The Standard Form 15 (SF-15), 'Application for 10-Point Veteran Preference,' also provides details on required documentation. Once you have more information, you can select the appropriate option from the previous page.
+
+*   [Return to disability/Purple Heart options.](./ownservice_disability_details.md)
+*   [Return to Advisor Start](./start.md)

--- a/advisor/ownservice_xp_generaldisability_details.md
+++ b/advisor/ownservice_xp_generaldisability_details.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Own Service: 10-Point Preference (XP) - General Disability
+---
+
+You indicated you have a present service-connected disability OR are receiving compensation, disability retirement benefits, or pension from the military or the Department of Veterans Affairs, not specifically categorized as 10-20% (CP) or 30%+ (CPS). [cite_start]This may qualify you for 10-point Veteran's Preference (XP), provided your discharge was (or will be, if VOW Act applies) under honorable conditions and all other general eligibility requirements are met. [cite_start]For disabled veterans, active duty includes training service in the Reserves or National Guard. [cite_start]Remember to complete the SF-15 form.
+
+*   [Confirm, proceed to eligibility summary.](./eligible_xp_10point.md)
+*   [I made a mistake, review disability/Purple Heart options.](./ownservice_disability_details.md)
+*   [Return to Advisor Start](./start.md)


### PR DESCRIPTION
Create Markdown files for Phase 2 disability paths

This commit adds three new Markdown files to the advisor section, corresponding to tasks in our plan:

- advisor/ownservice_cp_details.md: For veterans with a 10-20% service-connected disability.
- advisor/ownservice_xp_generaldisability_details.md: For veterans with a general service-connected disability not fitting other specific percentage categories.
- advisor/ownservice_disability_clarify_sf15.md: For veterans who need to clarify their disability status using documentation like the SF-15 form.

All files include specified content, layout, titles, and navigation links as outlined in the project plan.