### PR TITLE
Refactor: Overhaul citation system in advisor markdown files

### DIFF
--- a/advisor/advisor_audit_report.md
+++ b/advisor/advisor_audit_report.md
@@ -212,8 +212,8 @@ This section details the specific observations and discrepancies found during th
     *   `advisor/derived_mother_clarify_currentmarital.md` (common path: clarification)
     *   `advisor/eligible_xp_derived_mother.md` (common path: eligible outcome)
 *   **Advisor Logic:**
-    1.  `derived_mother_vetstatus.md`: User selects "Living AND is permanently and totally disabled from a service-connected injury or illness." This directly cites OPM [146].
-    2.  `derived_mother_living_vetseparation.md`: Asks if "veteran separated with an honorable or general discharge from active duty? (This active duty could have been performed at any time and includes training service in the Reserves or National Guard [cite: 146])". If "No," leads to `ineligible_derived_mother_living_vetseparation.md`. This aligns with OPM.
+    *   `advisor/derived_mother_vetstatus.md` (selects "Living AND is permanently and totally disabled...") This directly cites OPM (OPM Vet Guide, section [146]).
+    2.  `derived_mother_living_vetseparation.md`: Asks if "veteran separated with an honorable or general discharge from active duty? (This active duty could have been performed at any time and includes training service in the Reserves or National Guard (OPM Vet Guide, section [146]))". If "No," leads to `ineligible_derived_mother_living_vetseparation.md`. This aligns with OPM.
     3.  The path then merges with the common logic used for "Mother of Deceased Veteran":
         *   `derived_mother_common_fatherinfo.md`: Checks marriage to veteran's father.
         *   `derived_mother_common_currentmarital.md`: Checks mother's current marital/living status.
@@ -281,10 +281,10 @@ The main logical paths have been reviewed. Other specific details or less common
 ### Citation Issues
 
 *   (Initial observations, more detailed review in Task 1.2, which is dedicated to citations)
-    *   Citations are generally to page numbers in the OPM Vet Guide (e.g., `[cite: 123]`), which can be broad.
+    *   Citations are generally to page numbers in the OPM Vet Guide (e.g., `(OPM Vet Guide, section [123])`), which can be broad.
     *   Not all decision points or guidance statements derived from the Vet Guide are directly cited. For example, `ownservice_discharged_honorableconditions.md` explains honorable/general discharge requirements but doesn't have a specific citation number in that sentence.
-    *   The SSP files (`ineligible_ssp_reason.md`, `ineligible_s_s_p_dischargedate.md`) have `[cite_end]` without a preceding `[cite_start]` and actual citation number. This seems to be a formatting error. `ownservice_discharged_checkfirst_solesurvivor.md` correctly cites "OPM Vet Guide, '0-point Preference (SSP)'".
-    *   Some citations are to "OPM Vet Guide, 'Types of Preference'" which is a very broad section.
+    *   The SSP files (`ineligible_ssp_reason.md`, `ineligible_s_s_p_dischargedate.md`) have  without a preceding `[cite_start]` and actual citation number. This seems to be a formatting error. `ownservice_discharged_checkfirst_solesurvivor.md` correctly cites "(OPM Vet Guide, section [OPM Vet Guide, '0-point Preference (SSP)'])".
+    *   Some citations are to "(OPM Vet Guide, section [OPM Vet Guide, 'Types of Preference'])" which is a very broad section.
 
 ## Recommendations
 
@@ -315,7 +315,7 @@ Based on the findings of this audit, the following recommendations are made to i
 6.  **Citation Improvement (Cross-reference with Task 1.2):**
     *   Wherever possible, make citations more specific to sections or sub-sections of the OPM Vet Guide rather than just page numbers.
     *   Ensure all critical decision points based on Vet Guide rules have a corresponding citation.
-    *   Review and correct formatting errors for citations (e.g., `[cite_end]` issues).
+    *   Review and correct formatting errors for citations (e.g.,  issues).
 
 ## Conclusion
 

--- a/advisor/derived_intro.md
+++ b/advisor/derived_intro.md
@@ -5,7 +5,7 @@ title: Derived Veteran's Preference - Relationship to Veteran
 
 You are seeking to determine potential eligibility for veteran's preference based on the service of a qualifying veteran. This is generally a 10-point preference. What is your relationship to this veteran?
 
-[cite_start](Note: Applicants claiming 10-point preference must typically complete Standard Form (SF) 15, Application for 10-Point Veteran Preference, and submit the requested documentation [cite: 34]).
+(Note: Applicants claiming 10-point preference must typically complete Standard Form (SF) 15, Application for 10-Point Veteran Preference, and submit the requested documentation (OPM Vet Guide, section [34])).
 
 *   `"I am the spouse of a veteran."` -> `advisor/derived_spouse_vetliving.md`
 *   `"I am the widow or widower of a veteran."` -> `advisor/derived_widow_divorced.md`

--- a/advisor/derived_mother_common_currentmarital.md
+++ b/advisor/derived_mother_common_currentmarital.md
@@ -5,8 +5,8 @@ title: Mother's Preference - Current Living and Marital Status
 
 Which of the following best describes your current living and marital situation?
 
-*   [cite_start]`"I live with my husband (who is either the veteran's father or my husband through remarriage), and he is totally and permanently disabled."` [cite: 143, 148] -> `eligible_xp_derived_mother.md`
-*   [cite_start]`"I am widowed (from the veteran's father or a subsequent husband), divorced, or legally separated (from the veteran's father or a subsequent husband), AND I have not remarried since that specific event of widowhood, divorce, or separation."` (This covers [cite: 144, 149] [cite_start]and the essence of [cite: 145, 150]) -> `eligible_xp_derived_mother.md`
+*   `"I live with my husband (who is either the veteran's father or my husband through remarriage), and he is totally and permanently disabled."` (OPM Vet Guide, sections [143, 148]) -> `eligible_xp_derived_mother.md`
+*   `"I am widowed (from the veteran's father or a subsequent husband), divorced, or legally separated (from the veteran's father or a subsequent husband), AND I have not remarried since that specific event of widowhood, divorce, or separation."` (This covers (OPM Vet Guide, sections [144, 149]) and the essence of (OPM Vet Guide, sections [145, 150])) -> `eligible_xp_derived_mother.md`
 *   `"I am currently married, and my husband is NOT totally and permanently disabled."` -> `ineligible_derived_mother_currentmarital.md`
 *   `"None of these situations accurately describe mine."` -> `derived_mother_clarify_currentmarital.md`
 

--- a/advisor/derived_mother_common_fatherinfo.md
+++ b/advisor/derived_mother_common_fatherinfo.md
@@ -3,7 +3,7 @@ layout: default
 title: Mother's Preference - Relationship to Veteran's Father
 ---
 
-[cite_start]Are you now, or were you previously, married to the father of the veteran? [cite: 142, 147]
+Are you now, or were you previously, married to the father of the veteran? (OPM Vet Guide, sections [142, 147])
 
 * `"Yes."` -> `advisor/derived_mother_common_currentmarital.md`
 * `"No."` -> `advisor/ineligible_derived_mother_notmarriedtofather.md`

--- a/advisor/derived_mother_deceased_vetdeathcond.md
+++ b/advisor/derived_mother_deceased_vetdeathcond.md
@@ -6,9 +6,9 @@ title: Mother of Deceased Veteran - Conditions of Veteran's Death & Service
 Regarding your deceased veteran child: Did they die under honorable conditions while on active duty, AND was this active duty performed during:
 * a declared war (e.g., World War II), OR
 * the period April 28, 1952, through July 1, 1955, OR
-* [cite_start]in a campaign or expedition for which a campaign medal has been authorized? [cite: 141]
+* in a campaign or expedition for which a campaign medal has been authorized? (OPM Vet Guide, section [141])
 
 * `"Yes, all those conditions apply."` -> `advisor/derived_mother_common_fatherinfo.md`
-* [cite_start]`"No, those conditions do not all apply."` (This may include situations where the veteran's service was after 1955 but not in a war/campaign, making the mother ineligible for derived preference [cite: 152]) -> `advisor/ineligible_derived_mother_deceased_vetdeathcond.md`
+* `"No, those conditions do not all apply."` (This may include situations where the veteran's service was after 1955 but not in a war/campaign, making the mother ineligible for derived preference (OPM Vet Guide, section [152])) -> `advisor/ineligible_derived_mother_deceased_vetdeathcond.md`
 * `"[Return to previous question]"` -> `advisor/derived_mother_vetstatus.md`
 * `"[Return to Advisor Start]"` -> `advisor/start.md`

--- a/advisor/derived_mother_living_vetseparation.md
+++ b/advisor/derived_mother_living_vetseparation.md
@@ -3,7 +3,7 @@ layout: default
 title: Mother of Living Disabled Veteran - Veteran's Separation Conditions
 ---
 
-You indicated your veteran child is living and permanently and totally disabled from a service-connected injury or illness. Was this veteran separated with an honorable or general discharge from active duty? [cite_start](This active duty could have been performed at any time and includes training service in the Reserves or National Guard [cite: 146]).
+You indicated your veteran child is living and permanently and totally disabled from a service-connected injury or illness. Was this veteran separated with an honorable or general discharge from active duty? (This active duty could have been performed at any time and includes training service in the Reserves or National Guard (OPM Vet Guide, section [146])).
 
 * `"Yes, separated under honorable or general discharge."` -> `advisor/derived_mother_common_fatherinfo.md`
 * `"No, or discharge was different."` -> `advisor/ineligible_derived_mother_living_vetseparation.md`

--- a/advisor/derived_mother_vetstatus.md
+++ b/advisor/derived_mother_vetstatus.md
@@ -6,7 +6,7 @@ title: Derived Preference (Mother) - Veteran's Status (Deceased or Living Disabl
 Is the veteran (your son or daughter) on whose service you are basing your claim:
 
 * `"Deceased."` -> `advisor/derived_mother_deceased_vetdeathcond.md`
-* [cite_start]`"Living AND is permanently and totally disabled from a service-connected injury or illness."` [cite: 146] -> `advisor/derived_mother_living_vetseparation.md`
+* `"Living AND is permanently and totally disabled from a service-connected injury or illness."` (OPM Vet Guide, section [146]) -> `advisor/derived_mother_living_vetseparation.md`
 * `"Neither of these apply / I'm unsure."` -> `advisor/ineligible_derived_mother_vetstatus.md`
 * `"[Return to Relationship Choice]"` -> `advisor/derived_intro.md`
 * `"[Return to Advisor Start]"` -> `advisor/start.md`

--- a/advisor/derived_preference_step1.md
+++ b/advisor/derived_preference_step1.md
@@ -5,17 +5,17 @@ title: Veteran's Preference Advisor - Derived Preference Step 1
 
 # Derived Veteran's Preference
 
-[cite_start]You indicated you are seeking preference based on the service of a qualifying veteran, as a spouse, widow(er), or mother[cite: 129]. [cite_start]This is known as "derived preference" because it is based on the service of a veteran who is not able to use the preference[cite: 129].
+You indicated you are seeking preference based on the service of a qualifying veteran, as a spouse, widow(er), or mother (OPM Vet Guide, section [129]). This is known as "derived preference" because it is based on the service of a veteran who is not able to use the preference (OPM Vet Guide, section [129]).
 
 To determine potential eligibility, we first need information about the **veteran** on whose service this claim is based.
 
 Is the veteran living?
 
 * **[Yes, the veteran is living.](derived_preference_living_vet_step2.md)**
-    * [cite_start]*In cases of derived preference for a spouse or mother of a living veteran, specific conditions apply, such as the veteran being unable to use the preference themselves due to disqualification or disability[cite: 131, 147].*
+    * *In cases of derived preference for a spouse or mother of a living veteran, specific conditions apply, such as the veteran being unable to use the preference themselves due to disqualification or disability (OPM Vet Guide, sections [131, 147]).*
 
 * **[No, the veteran is deceased.](derived_preference_deceased_vet_step2.md)**
-    * [cite_start]*Derived preference for widows/widowers or mothers of deceased veterans also has specific qualifying conditions related to the veteran's service and the circumstances of their death[cite: 140, 142].*
+    * *Derived preference for widows/widowers or mothers of deceased veterans also has specific qualifying conditions related to the veteran's service and the circumstances of their death (OPM Vet Guide, sections [140, 142]).*
 
 ---
 *This advisor provides guidance based on the U.S. Office of Personnel Management (OPM) Vet Guide for HR Professionals. For official determinations, please consult directly with the hiring agency or OPM.*

--- a/advisor/derived_spouse_furtherclarification.md
+++ b/advisor/derived_spouse_furtherclarification.md
@@ -3,7 +3,7 @@ layout: default
 title: Derived Preference (Spouse): Further Clarification Recommended
 ---
 
-You've indicated the veteran is disqualified for their usual occupation due to a service-connected disability, but the specific conditions for a presumed disqualification were not selected. [cite_start]OPM states that preference *may* be allowed in other circumstances, but this "warrants a more careful analysis" by the hiring agency[cite: 136].
+You've indicated the veteran is disqualified for their usual occupation due to a service-connected disability, but the specific conditions for a presumed disqualification were not selected. OPM states that preference *may* be allowed in other circumstances, but this "warrants a more careful analysis" by the hiring agency (OPM Vet Guide, section [136]).
 
 You will need to provide detailed documentation with your SF-15. This advisor cannot make a determination in such cases, but you may still be eligible.
 

--- a/advisor/derived_spouse_vetdisabilitydetails.md
+++ b/advisor/derived_spouse_vetdisabilitydetails.md
@@ -5,9 +5,9 @@ title: Derived Preference (Spouse): Veteran's Disability Details
 
 You indicated the veteran is disqualified for their usual occupation due to a service-connected disability. Such disqualification may be presumed if the veteran is unemployed AND one of the following situations applies. Which best describes the veteran's situation?
 
-*   [cite_start]`"The veteran is unemployed AND is rated by appropriate military or Department of Veterans Affairs authorities to be 100 percent disabled and/or unemployable."` [cite: 133] -> `advisor/eligible_xp_derived_spouse.md`
-*   [cite_start]`"The veteran is unemployed AND has retired, been separated, or resigned from a civil service position on the basis of a disability that is service-connected in origin."` [cite: 134] -> `advisor/eligible_xp_derived_spouse.md`
-*   [cite_start]`"The veteran is unemployed AND has attempted to obtain a civil service position or other position along the lines of his or her usual occupation and has failed to qualify because of a service-connected disability."` [cite: 135] -> `advisor/eligible_xp_derived_spouse.md`
+*   `"The veteran is unemployed AND is rated by appropriate military or Department of Veterans Affairs authorities to be 100 percent disabled and/or unemployable."` (OPM Vet Guide, section [133]) -> `advisor/eligible_xp_derived_spouse.md`
+*   `"The veteran is unemployed AND has retired, been separated, or resigned from a civil service position on the basis of a disability that is service-connected in origin."` (OPM Vet Guide, section [134]) -> `advisor/eligible_xp_derived_spouse.md`
+*   `"The veteran is unemployed AND has attempted to obtain a civil service position or other position along the lines of his or her usual occupation and has failed to qualify because of a service-connected disability."` (OPM Vet Guide, section [135]) -> `advisor/eligible_xp_derived_spouse.md`
 *   `"The veteran is disqualified due to a service-connected disability, but none of the specific situations above fully apply, or I'm unsure."` -> `advisor/derived_spouse_furtherclarification.md`
 
 [Return to previous question](./derived_spouse_vetdisabilityreason.md)

--- a/advisor/derived_spouse_vetdisabilityreason.md
+++ b/advisor/derived_spouse_vetdisabilityreason.md
@@ -3,7 +3,7 @@ layout: default
 title: Derived Preference (Spouse): Reason for Veteran's Non-Qualification
 ---
 
-[cite_start]Is the veteran disqualified for a Federal position along the general lines of his or her usual occupation *because of a service-connected disability*? [cite: 132]
+Is the veteran disqualified for a Federal position along the general lines of his or her usual occupation *because of a service-connected disability*? (OPM Vet Guide, section [132])
 
 *   `"Yes, due to a service-connected disability."` -> `advisor/derived_spouse_vetdisabilitydetails.md`
 *   `"No, the reason is not a service-connected disability."` -> `advisor/ineligible_derived_spouse_vetnotdisabled.md`

--- a/advisor/derived_spouse_vetqualifiedforemployment.md
+++ b/advisor/derived_spouse_vetqualifiedforemployment.md
@@ -5,7 +5,7 @@ title: Derived Preference (Spouse): Veteran's Employment Qualification
 
 Is the living veteran qualified for Federal employment (i.e., able to work and apply for Federal jobs)?
 
-[cite_start](A spouse generally cannot receive preference if the veteran is living and is qualified for Federal employment [cite: 131]).
+(A spouse generally cannot receive preference if the veteran is living and is qualified for Federal employment (OPM Vet Guide, section [131])).
 
 *   `"Yes, the veteran is living and qualified for Federal employment."` -> `advisor/ineligible_derived_spouse_vetqualified.md`
 *   `"No, the veteran is living but is NOT qualified for Federal employment."` -> `advisor/derived_spouse_vetdisabilityreason.md`

--- a/advisor/derived_widow_clarify_vetservice.md
+++ b/advisor/derived_widow_clarify_vetservice.md
@@ -7,9 +7,9 @@ To determine eligibility, please review the veteran's service records (such as t
 * A declared war (e.g., World War II: December 7, 1941 - April 28, 1952).
 * Service during the period April 28, 1952, through July 1, 1955.
 * Service in a campaign or expedition for which a campaign medal was authorized (see OPM Vet Guide Appendix A).
-* [cite_start]Also, verify if the veteran died while on active duty during such service, under conditions that would not have been the basis for other than an honorable or general discharge[cite: 140].
+* Also, verify if the veteran died while on active duty during such service, under conditions that would not have been the basis for other than an honorable or general discharge (OPM Vet Guide, section [140]).
 
-[cite_start]You can find details in the OPM Vet Guide under "10-Point Derived Preference (XP) - Widow/Widower"[cite: 139, 152].
+You can find details in the OPM Vet Guide under "10-Point Derived Preference (XP) - Widow/Widower" (OPM Vet Guide, sections [139, 152]).
 
 * `"[Return to veteran's service condition choices]"` -> `advisor/derived_widow_vetservice_condition.md`
 * `"[Return to Advisor Start]"` -> `advisor/start.md`

--- a/advisor/derived_widow_divorced.md
+++ b/advisor/derived_widow_divorced.md
@@ -3,7 +3,7 @@ layout: default
 title: Derived Preference (Widow/Widower): Marital Status at Veteran's Death
 ---
 
-[cite_start]Were you divorced from the veteran at the time of their death? [cite: 139]
+Were you divorced from the veteran at the time of their death? (OPM Vet Guide, section [139])
 
 *   `"Yes, I was divorced."` -> `ineligible_derived_widow_divorced.md`
 *   `"No, I was not divorced."` -> `derived_widow_remarried.md`

--- a/advisor/derived_widow_remarried.md
+++ b/advisor/derived_widow_remarried.md
@@ -4,7 +4,7 @@ title: Derived Preference (Widow/Widower): Remarriage Status
 ---
 ## Derived Preference (Widow/Widower): Remarriage Status
 
-Have you remarried since the veteran's death? [cite_start](If you remarried but that subsequent marriage was annulled, select 'No, or my remarriage was annulled.') [cite: 139]
+Have you remarried since the veteran's death? (If you remarried but that subsequent marriage was annulled, select 'No, or my remarriage was annulled.' (OPM Vet Guide, section [139]))
 
 * [Yes, I have remarried (and the marriage was not annulled).](./ineligible_derived_widow_remarried.md)
 * [No, I have not remarried OR my subsequent remarriage was annulled.](./derived_widow_vetservice_condition.md)

--- a/advisor/derived_widow_vetservice_condition.md
+++ b/advisor/derived_widow_vetservice_condition.md
@@ -6,9 +6,9 @@ title: Derived Preference (Widow/Widower): Veteran's Service or Death Conditions
 
 Which of the following conditions applied to the veteran?
 
-* [cite_start]"The veteran served during a declared war (e.g., World War II: Dec 7, 1941 - Apr 28, 1952), OR during the period April 28, 1952, through July 1, 1955, OR in a campaign or expedition for which a campaign medal has been authorized (see OPM Vet Guide Appendix A for a list of medals)." [cite: 139]](./eligible_xp_derived_widow.md)
-* [cite_start]"The veteran died while on active duty (that included service as described in the option above) under conditions that would not have been the basis for other than an honorable or general discharge." [cite: 140]](./eligible_xp_derived_widow.md)
-* [cite_start]"The veteran's service was after 1955 and was NOT in a war, campaign, or expedition for which a medal was authorized, AND they did not die on active duty during such specific service." (As per OPM Vet Guide, 'Note' following 5 U.S.C. 2108 (1) (B), (C) or (2) [cite: 152])](./ineligible_derived_widow_vetservicenotqualifying.md)
+* "The veteran served during a declared war (e.g., World War II: Dec 7, 1941 - Apr 28, 1952), OR during the period April 28, 1952, through July 1, 1955, OR in a campaign or expedition for which a campaign medal has been authorized (see OPM Vet Guide Appendix A for a list of medals)." (OPM Vet Guide, section [139])](./eligible_xp_derived_widow.md)
+* "The veteran died while on active duty (that included service as described in the option above) under conditions that would not have been the basis for other than an honorable or general discharge." (OPM Vet Guide, section [140])](./eligible_xp_derived_widow.md)
+* "The veteran's service was after 1955 and was NOT in a war, campaign, or expedition for which a medal was authorized, AND they did not die on active duty during such specific service." (As per OPM Vet Guide, 'Note' following 5 U.S.C. 2108 (1) (B), (C) or (2) (OPM Vet Guide, section [152]))](./ineligible_derived_widow_vetservicenotqualifying.md)
 * [None of these, or I'm unsure.](./derived_widow_clarify_vetservice.md)
 * [Return to previous question](./derived_widow_remarried.md)
 * [Return to Advisor Start](./start.md)

--- a/advisor/eligible_cp_10point.md
+++ b/advisor/eligible_cp_10point.md
@@ -3,13 +3,13 @@ layout: default
 title: Veteran's Preference Advisor - Potential 10-Point Eligibility (CP)
 ---
 
-[cite_start]Based on your responses, you appear to meet the criteria for 10-point veteran's preference (CP) due to a service-connected disability rating of at least 10 percent but less than 30 percent. This is an initial assessment and not a final determination of preference.
+Based on your responses, you appear to meet the criteria for 10-point veteran's preference (CP) due to a service-connected disability rating of at least 10 percent but less than 30 percent. This is an initial assessment and not a final determination of preference.
 
 Key considerations for CP preference:
-* [cite_start]You must have been discharged or released from active duty under honorable conditions (or expect to be if applying under the VOW Act).
-* [cite_start]Applicants claiming 10-point preference must typically complete Standard Form (SF) 15, Application for 10-Point Veteran Preference, and submit required documentation (like your VA rating decision).
-* [cite_start]For disabled veterans, "active duty" includes training service in the Reserves or National Guard.
-* [cite_start]The 24-month minimum active duty service requirement that applies to some 5-point preference situations generally does not apply to those eligible for 10-point preference due to a separation for disability incurred or aggravated in the line of duty.
+* You must have been discharged or released from active duty under honorable conditions (or expect to be if applying under the VOW Act).
+* Applicants claiming 10-point preference must typically complete Standard Form (SF) 15, Application for 10-Point Veteran Preference, and submit required documentation (like your VA rating decision).
+* For disabled veterans, "active duty" includes training service in the Reserves or National Guard.
+* The 24-month minimum active duty service requirement that applies to some 5-point preference situations generally does not apply to those eligible for 10-point preference due to a separation for disability incurred or aggravated in the line of duty.
 
 Remember to claim preference when applying for Federal jobs and be prepared to provide documentation.
 

--- a/advisor/eligible_cps_10point.md
+++ b/advisor/eligible_cps_10point.md
@@ -3,13 +3,13 @@ layout: default
 title: Veteran's Preference Advisor - Potential 10-Point Eligibility (CPS)
 ---
 
-[cite_start]Based on your responses, you appear to meet the criteria for 10-point veteran's preference (CPS) due to a service-connected disability rating of 30 percent or more. This is an initial assessment and not a final determination of preference.
+Based on your responses, you appear to meet the criteria for 10-point veteran's preference (CPS) due to a service-connected disability rating of 30 percent or more. This is an initial assessment and not a final determination of preference.
 
 Key considerations for CPS preference:
-* [cite_start]You must have been discharged or released from active duty under honorable conditions (or expect to be if applying under the VOW Act).
-* [cite_start]Applicants claiming 10-point preference must typically complete Standard Form (SF) 15, Application for 10-Point Veteran Preference, and submit required documentation (like your VA rating decision).
-* [cite_start]For disabled veterans, "active duty" includes training service in the Reserves or National Guard.
-* [cite_start]The 24-month minimum active duty service requirement that applies to some 5-point preference situations generally does not apply to those eligible for 10-point preference due to a separation for disability incurred or aggravated in the line of duty.
+* You must have been discharged or released from active duty under honorable conditions (or expect to be if applying under the VOW Act).
+* Applicants claiming 10-point preference must typically complete Standard Form (SF) 15, Application for 10-Point Veteran Preference, and submit required documentation (like your VA rating decision).
+* For disabled veterans, "active duty" includes training service in the Reserves or National Guard.
+* The 24-month minimum active duty service requirement that applies to some 5-point preference situations generally does not apply to those eligible for 10-point preference due to a separation for disability incurred or aggravated in the line of duty.
 
 Remember to claim preference when applying for Federal jobs and be prepared to provide documentation.
 

--- a/advisor/eligible_xp_10point.md
+++ b/advisor/eligible_xp_10point.md
@@ -3,14 +3,14 @@ layout: default
 title: Veteran's Preference Advisor - Potential 10-Point Eligibility (XP)
 ---
 
-[cite_start]Based on your responses, you appear to meet the criteria for 10-point veteran's preference (XP). This is an initial assessment and not a final determination of preference.
+Based on your responses, you appear to meet the criteria for 10-point veteran's preference (XP). This is an initial assessment and not a final determination of preference.
 
 Key considerations for XP preference:
-* [cite_start]It can be based on receiving a Purple Heart OR having a service-connected disability (or receiving compensation/pension for it) that doesn't fall into the specific CP (10-20%) or CPS (30%+) categories.
-* [cite_start]You must have been discharged or released from active duty under honorable conditions (or expect to be if applying under the VOW Act).
-* [cite_start]Applicants claiming 10-point preference must typically complete Standard Form (SF) 15, Application for 10-Point Veteran Preference, and submit required documentation.
-* [cite_start]For disabled veterans, "active duty" includes training service in the Reserves or National Guard.
-* [cite_start]The 24-month minimum active duty service requirement that applies to some 5-point preference situations generally does not apply to those eligible for 10-point preference due to a separation for disability incurred or aggravated in the line of duty.
+* It can be based on receiving a Purple Heart OR having a service-connected disability (or receiving compensation/pension for it) that doesn't fall into the specific CP (10-20%) or CPS (30%+) categories.
+* You must have been discharged or released from active duty under honorable conditions (or expect to be if applying under the VOW Act).
+* Applicants claiming 10-point preference must typically complete Standard Form (SF) 15, Application for 10-Point Veteran Preference, and submit required documentation.
+* For disabled veterans, "active duty" includes training service in the Reserves or National Guard.
+* The 24-month minimum active duty service requirement that applies to some 5-point preference situations generally does not apply to those eligible for 10-point preference due to a separation for disability incurred or aggravated in the line of duty.
 
 Remember to claim preference when applying for Federal jobs and be prepared to provide documentation.
 

--- a/advisor/eligible_xp_derived_spouse.md
+++ b/advisor/eligible_xp_derived_spouse.md
@@ -3,7 +3,7 @@ layout: default
 title: Veteran's Preference Advisor - Potential 10-Point Derived Preference (XP) - Spouse
 ---
 
-[cite_start]Based on your responses, you appear to meet the criteria for 10-point derived veteran's preference (XP) as the spouse of a veteran who is disqualified for a Federal position along the general lines of his or her usual occupation because of a service-connected disability[cite: 132, 133, 134, 135].
+Based on your responses, you appear to meet the criteria for 10-point derived veteran's preference (XP) as the spouse of a veteran who is disqualified for a Federal position along the general lines of his or her usual occupation because of a service-connected disability (OPM Vet Guide, sections [132, 133, 134, 135]).
 
 This is an initial assessment and not a final determination of preference. Remember to:
 * Claim preference when applying for Federal jobs.

--- a/advisor/eligible_xp_derived_spouse_conditional.md
+++ b/advisor/eligible_xp_derived_spouse_conditional.md
@@ -5,7 +5,7 @@ title: Veteran's Preference Advisor - Potential Conditional 10-Point Derived Pre
 
 Based on your responses, you *may* meet the criteria for 10-point derived veteran's preference (XP) as the spouse of a veteran disqualified for their usual occupation due to a service-connected disability.
 
-[cite_start]However, because your situation does not fall under the standard presumptions for disqualification, your claim will require a more careful analysis by the hiring agency, and possibly OPM[cite: 136].
+However, because your situation does not fall under the standard presumptions for disqualification, your claim will require a more careful analysis by the hiring agency, and possibly OPM (OPM Vet Guide, section [136]).
 
 Key reminders:
 *   Complete the SF-15, Application for 10-Point Veteran Preference.

--- a/advisor/eligible_xp_derived_widow.md
+++ b/advisor/eligible_xp_derived_widow.md
@@ -3,7 +3,7 @@ layout: default
 title: Veteran's Preference Advisor - Potential 10-Point Derived Preference (XP) - Widow/Widower
 ---
 
-[cite_start]Based on your responses, you appear to meet the criteria for 10-point derived veteran's preference (XP) as the widow/widower of a qualifying veteran[cite: 139, 140].
+Based on your responses, you appear to meet the criteria for 10-point derived veteran's preference (XP) as the widow/widower of a qualifying veteran (OPM Vet Guide, sections [139, 140]).
 
 This is an initial assessment and not a final determination of preference. Remember to:
 * Claim preference when applying for Federal jobs.

--- a/advisor/ineligible_derived_mother_currentmarital.md
+++ b/advisor/ineligible_derived_mother_currentmarital.md
@@ -4,8 +4,8 @@ title: Mother's Preference: Potentially Ineligible - Current Marital/Living Stat
 ---
 
 To be eligible for derived preference as a mother, your current marital and living situation must meet specific criteria. These include:
-* [cite_start]Living with your husband (veteran's father or remarried husband) who is totally and permanently disabled[cite: 143, 148], OR
-* [cite_start]Being widowed, divorced, or legally separated (from veteran's father or subsequent husband) and not having remarried since that event[cite: 144, 145, 149, 150].
+* Living with your husband (veteran's father or remarried husband) who is totally and permanently disabled (OPM Vet Guide, sections [143, 148]), OR
+* Being widowed, divorced, or legally separated (from veteran's father or subsequent husband) and not having remarried since that event (OPM Vet Guide, sections [144, 145, 149, 150]).
 
 Based on your response (currently married and husband is not P&T disabled), you may not meet these conditions.
 

--- a/advisor/ineligible_derived_mother_deceased_vetdeathcond.md
+++ b/advisor/ineligible_derived_mother_deceased_vetdeathcond.md
@@ -3,7 +3,7 @@ layout: default
 title: Mother's Preference - Potentially Ineligible - Deceased Veteran's Service/Death Conditions
 ---
 
-[cite_start]For a mother to claim preference for a deceased veteran, the veteran generally must have died under honorable conditions while on active duty during a declared war, specific post-war periods (April 28, 1952 - July 1, 1955), or in a campaign or expedition for which a campaign medal was authorized[cite: 141]. [cite_start]Preference is also generally not granted if the deceased veteran's own preference eligibility was based *only* on other criteria (e.g., service after 1955 not in a war/campaign)[cite: 152]. Based on your responses, these conditions may not be met.
+For a mother to claim preference for a deceased veteran, the veteran generally must have died under honorable conditions while on active duty during a declared war, specific post-war periods (April 28, 1952 - July 1, 1955), or in a campaign or expedition for which a campaign medal was authorized (OPM Vet Guide, section [141]). Preference is also generally not granted if the deceased veteran's own preference eligibility was based *only* on other criteria (e.g., service after 1955 not in a war/campaign) (OPM Vet Guide, section [152]). Based on your responses, these conditions may not be met.
 
 *   `"[Return to check veteran's death/service conditions]"` -> `derived_mother_deceased_vetdeathcond.md`
 *   `"[Return to Relationship Choice]"` -> `derived_intro.md`

--- a/advisor/ineligible_derived_mother_living_vetseparation.md
+++ b/advisor/ineligible_derived_mother_living_vetseparation.md
@@ -3,7 +3,7 @@ layout: default
 title: Mother's Preference - Potentially Ineligible - Living Veteran's Separation
 ---
 
-[cite_start]For a mother to claim preference for a living, permanently and totally disabled veteran, the veteran must have been separated from active duty (including training service) with an honorable or general discharge[cite: 146]. Based on your response, this condition may not be met.
+For a mother to claim preference for a living, permanently and totally disabled veteran, the veteran must have been separated from active duty (including training service) with an honorable or general discharge (OPM Vet Guide, section [146]). Based on your response, this condition may not be met.
 
 *   `"[Return to check veteran's separation]"` -> `derived_mother_living_vetseparation.md`
 *   `"[Return to Relationship Choice]"` -> `derived_intro.md`

--- a/advisor/ineligible_derived_mother_notmarriedtofather.md
+++ b/advisor/ineligible_derived_mother_notmarriedtofather.md
@@ -3,7 +3,7 @@ layout: default
 title: Mother's Preference - Potentially Ineligible - Marriage to Veteran's Father
 ---
 
-[cite_start]To be eligible for derived preference as a mother, you must be (or have been) married to the father of the veteran[cite: 142, 147]. Based on your response, this condition may not be met.
+To be eligible for derived preference as a mother, you must be (or have been) married to the father of the veteran (OPM Vet Guide, sections [142, 147]). Based on your response, this condition may not be met.
 
 *   `"[Return to check marriage to veteran's father]"` -> `derived_mother_common_fatherinfo.md`
 *   `"[Return to Relationship Choice]"` -> `derived_intro.md`

--- a/advisor/ineligible_derived_mother_vetstatus.md
+++ b/advisor/ineligible_derived_mother_vetstatus.md
@@ -4,8 +4,8 @@ title: Mother's Preference - Potentially Ineligible - Veteran's Status
 ---
 
 To be eligible for derived preference as a mother, the veteran (your son or daughter) must generally be either:
-1. [cite_start]Deceased under specific conditions related to their active duty service (during a war, specific period, or campaign)[cite: 141], OR
-2. [cite_start]Living and permanently and totally disabled from a service-connected injury or illness, and honorably separated[cite: 146].
+1. Deceased under specific conditions related to their active duty service (during a war, specific period, or campaign) (OPM Vet Guide, section [141]), OR
+2. Living and permanently and totally disabled from a service-connected injury or illness, and honorably separated (OPM Vet Guide, section [146]).
 
 Based on your response, the veteran's status may not meet these requirements.
 

--- a/advisor/ineligible_derived_spouse_vetnotdisabled.md
+++ b/advisor/ineligible_derived_spouse_vetnotdisabled.md
@@ -3,7 +3,7 @@ layout: default
 title: Derived Preference (Spouse): Potentially Ineligible - Disqualification Not Due to Service-Connected Disability
 ---
 
-[cite_start]For a spouse to claim derived preference for a living veteran, the veteran must be disqualified for a Federal position along the general lines of his or her usual occupation *because of a service-connected disability*[cite: 132]. Based on your response that the disqualification is not due to a service-connected disability, you may not be eligible for derived preference.
+For a spouse to claim derived preference for a living veteran, the veteran must be disqualified for a Federal position along the general lines of his or her usual occupation *because of a service-connected disability* (OPM Vet Guide, section [132]). Based on your response that the disqualification is not due to a service-connected disability, you may not be eligible for derived preference.
 
 *   `[Return to check reason for non-qualification]` -> `derived_spouse_vetdisabilityreason.md`
 *   `[Return to Relationship Choice]` -> `derived_intro.md`

--- a/advisor/ineligible_derived_spouse_vetqualified.md
+++ b/advisor/ineligible_derived_spouse_vetqualified.md
@@ -3,7 +3,7 @@ layout: default
 title: Derived Preference (Spouse): Potentially Ineligible - Veteran Qualified
 ---
 
-[cite_start]Generally, a spouse cannot receive derived preference if the veteran is living and qualified for Federal employment[cite: 131]. Based on your response, you may not be eligible for derived preference as a spouse under this condition.
+Generally, a spouse cannot receive derived preference if the veteran is living and qualified for Federal employment (OPM Vet Guide, section [131]). Based on your response, you may not be eligible for derived preference as a spouse under this condition.
 
 *   `[Return to check veteran's employment qualification]` -> `derived_spouse_vetqualifiedforemployment.md`
 *   `[Return to Relationship Choice]` -> `derived_intro.md`

--- a/advisor/ineligible_derived_widow_divorced.md
+++ b/advisor/ineligible_derived_widow_divorced.md
@@ -4,7 +4,7 @@ title: Derived Preference (Widow/Widower): Potentially Ineligible - Divorced
 ---
 ## Derived Preference (Widow/Widower): Potentially Ineligible - Divorced
 
-[cite_start]To be eligible for derived preference as a widow or widower, you must not have been divorced from the veteran at the time of their death[cite: 139]. Based on your response, you may not be eligible.
+To be eligible for derived preference as a widow or widower, you must not have been divorced from the veteran at the time of their death (OPM Vet Guide, section [139]). Based on your response, you may not be eligible.
 
 * [Return to check marital status at death](./derived_widow_divorced.md)
 * [Return to Relationship Choice](./derived_intro.md)

--- a/advisor/ineligible_derived_widow_remarried.md
+++ b/advisor/ineligible_derived_widow_remarried.md
@@ -4,7 +4,7 @@ title: Derived Preference (Widow/Widower): Potentially Ineligible - Remarried
 ---
 ## Derived Preference (Widow/Widower): Potentially Ineligible - Remarried
 
-[cite_start]To be eligible for derived preference as a widow or widower, you must not have remarried since the veteran's death, or if you remarried, that subsequent marriage must have been annulled[cite: 139]. Based on your response, you may not be eligible.
+To be eligible for derived preference as a widow or widower, you must not have remarried since the veteran's death, or if you remarried, that subsequent marriage must have been annulled (OPM Vet Guide, section [139]). Based on your response, you may not be eligible.
 
 * [Return to check remarriage status](./derived_widow_remarried.md)
 * [Return to Relationship Choice](./derived_intro.md)

--- a/advisor/ineligible_derived_widow_vetservicenotqualifying.md
+++ b/advisor/ineligible_derived_widow_vetservicenotqualifying.md
@@ -4,9 +4,9 @@ title: Derived Preference (Widow/Widower): Potentially Ineligible - Veteran's Se
 ---
 ## Derived Preference (Widow/Widower): Potentially Ineligible - Veteran's Service
 
-For derived preference as a widow/widower, the veteran's service generally must have been during a declared war, specific post-war periods (April 28, 1952 - July 1, 1955), or in a campaign or expedition for which a medal was authorized; [cite_start]OR the veteran must have died on active duty during such qualifying service[cite: 139, 140].
+For derived preference as a widow/widower, the veteran's service generally must have been during a declared war, specific post-war periods (April 28, 1952 - July 1, 1955), or in a campaign or expedition for which a medal was authorized; OR the veteran must have died on active duty during such qualifying service (OPM Vet Guide, sections [139, 140]).
 
-[cite_start]Preference is generally not granted to widows or mothers if the deceased veteran's own preference eligibility was based *only* on other criteria (e.g., service after 1955 that was not in a war or campaign, such as >180 days of active duty or Gulf War service without a specific campaign medal)[cite: 152]. Based on your response, the veteran's service may not qualify for this type of derived preference.
+Preference is generally not granted to widows or mothers if the deceased veteran's own preference eligibility was based *only* on other criteria (e.g., service after 1955 that was not in a war or campaign, such as >180 days of active duty or Gulf War service without a specific campaign medal) (OPM Vet Guide, section [152]). Based on your response, the veteran's service may not qualify for this type of derived preference.
 
 * [Return to check veteran's service conditions](./derived_widow_vetservice_condition.md)
 * [Return to Relationship Choice](./derived_intro.md)

--- a/advisor/ineligible_discharge_type.md
+++ b/advisor/ineligible_discharge_type.md
@@ -3,6 +3,6 @@ layout: default
 title: "Own Service: Ineligible - Discharge Not Under Honorable Conditions"
 ---
 
-Veteran's preference requires a discharge or release under honorable conditions (i.e., an Honorable or General discharge). (OPM Vet Guide, 'Types of Preference'). If your discharge was of a different character, you may not be eligible.
+Veteran's preference requires a discharge or release under honorable conditions (i.e., an Honorable or General discharge). (OPM Vet Guide, section ['Types of Preference']). If your discharge was of a different character, you may not be eligible.
 
 *   [Return to Advisor Start](./start.md)

--- a/advisor/ineligible_general.md
+++ b/advisor/ineligible_general.md
@@ -3,6 +3,6 @@ layout: default
 title: Veteran's Preference Advisor - Initial Ineligibility
 ---
 
-Based on your initial selection, it appears you may not be directly pursuing veteran's preference based on your own service or as a qualifying relative (spouse, widow(er), mother) of a veteran. This advisor focuses on those categories. Veteran's preference is a specific entitlement for those who served in the Armed Forces during certain periods or campaigns, or have service-connected disabilities, and for certain family members (see OPM Vet Guide, 'Why Preference is Given').
+Based on your initial selection, it appears you may not be directly pursuing veteran's preference based on your own service or as a qualifying relative (spouse, widow(er), mother) of a veteran. This advisor focuses on those categories. Veteran's preference is a specific entitlement for those who served in the Armed Forces during certain periods or campaigns, or have service-connected disabilities, and for certain family members (see OPM Vet Guide, section ['Why Preference is Given']).
 
 *   [Return to Advisor Start](./start.md)

--- a/advisor/ineligible_ownservice_noqualifyingperiod.md
+++ b/advisor/ineligible_ownservice_noqualifyingperiod.md
@@ -3,7 +3,7 @@ title: "Veteran's Preference Advisor - Potentially Ineligible for 5-Point Prefer
 layout: default
 ---
 
-Based on your responses, it appears your service does not fall into the specified periods or involve a qualifying campaign medal for 5-point preference (TP) as a veteran who, in this path, has not indicated a service-connected disability or sole survivorship discharge. (See OPM Vet Guide, '5-Point Preference (TP)'). If you made an error or wish to explore other preference types (like based on disability), please return to the relevant section.
+Based on your responses, it appears your service does not fall into the specified periods or involve a qualifying campaign medal for 5-point preference (TP) as a veteran who, in this path, has not indicated a service-connected disability or sole survivorship discharge. (See OPM Vet Guide, section ['5-Point Preference (TP)']). If you made an error or wish to explore other preference types (like based on disability), please return to the relevant section.
 
 Choices:
 *   [I want to re-check for disability preference (10-point) or sole survivorship.](./ownservice_checkdisability_intro.md)

--- a/advisor/ineligible_ownservice_status.md
+++ b/advisor/ineligible_ownservice_status.md
@@ -3,7 +3,7 @@ layout: default
 title: Ineligible Based on Current Service Status
 ---
 
-Based on your responses, you do not currently meet the preliminary requirements for veteran's preference. Generally, you must be discharged or released from active duty under honorable conditions to be eligible. If you are still on active duty, you may be eligible under the VOW Act if you are within 120 days of discharge and can provide a certification. <!-- TODO: Add link to VOW Act info or back to VOW questions if applicable --> For more information, please review the OPM Vet Guide [Appendix A - Definitions of Terms and Categories, Page 31].
+Based on your responses, you do not currently meet the preliminary requirements for veteran's preference. Generally, you must be discharged or released from active duty under honorable conditions to be eligible. If you are still on active duty, you may be eligible under the VOW Act if you are within 120 days of discharge and can provide a certification. <!-- TODO: Add link to VOW Act info or back to VOW questions if applicable --> For more information, please review the OPM Vet Guide (OPM Vet Guide, section [Appendix A - Definitions of Terms and Categories, Page 31]).
 
 *   [I made a mistake in my previous answers, take me back.](./ownservice_intro.md)
 *   [Return to Advisor Start](./start.md)

--- a/advisor/ineligible_retiredmajor_notdisabled.md
+++ b/advisor/ineligible_retiredmajor_notdisabled.md
@@ -3,6 +3,6 @@ layout: default
 title: "Own Service: Ineligible - Retired Officer Not Disabled"
 ---
 
-Military retirees at the rank of Major, Lieutenant Commander, or higher are not eligible for preference in appointment unless they are disabled veterans. (OPM Vet Guide, 'Types of Preference'). Based on your responses, you may not be eligible for veteran's preference under this condition.
+Military retirees at the rank of Major, Lieutenant Commander, or higher are not eligible for preference in appointment unless they are disabled veterans. (OPM Vet Guide, section ['Types of Preference']). Based on your responses, you may not be eligible for veteran's preference under this condition.
 
 *   [Return to Advisor Start](./start.md)

--- a/advisor/ineligible_ssp_dischargedate.md
+++ b/advisor/ineligible_ssp_dischargedate.md
@@ -3,7 +3,7 @@ layout: default
 title: Sole Survivor Preference: Potentially Ineligible - Discharge Date Not Met
 ---
 
-[cite_start]To be eligible for 0-point Sole Survivor Preference (SSP) under the Hubbard Act, your release or discharge from active duty must have occurred *after August 29, 2008*. [cite_end]
+To be eligible for 0-point Sole Survivor Preference (SSP) under the Hubbard Act, your release or discharge from active duty must have occurred *after August 29, 2008*.
 
 Based on your response, your discharge date does not meet this requirement for SSP. You may still be eligible for other types of veteran's preference based on your service.
 

--- a/advisor/ineligible_ssp_reason.md
+++ b/advisor/ineligible_ssp_reason.md
@@ -3,7 +3,7 @@ layout: default
 title: Sole Survivor Preference: Potentially Ineligible - Reason for Discharge Not Met
 ---
 
-[cite_start]Eligibility for 0-point Sole Survivor Preference (SSP) requires that the specific reason for your discharge (after August 29, 2008) was a 'sole survivorship discharge'.[cite_end]
+Eligibility for 0-point Sole Survivor Preference (SSP) requires that the specific reason for your discharge (after August 29, 2008) was a 'sole survivorship discharge'.
 
 If your discharge was for other reasons, you would not qualify for SSP. However, you might be eligible for other types of veteran's preference (e.g., 5-point preference based on service period or campaign medal, or 10-point preference if disabled).
 

--- a/advisor/ineligible_tp_minduration.md
+++ b/advisor/ineligible_tp_minduration.md
@@ -3,7 +3,7 @@ title: "Veteran's Preference Advisor - Ineligible for 5-Point Preference (Minimu
 layout: default
 ---
 
-To qualify for 5-point preference based on your service period and original enlistment/active duty start date (after Sep 7, 1980/Oct 14, 1982), you generally must have served continuously for 24 months OR the full period for which you were called or ordered to active duty, unless specific exceptions apply (like a separation for service-connected disability qualifying for 10-point preference, or a hardship separation). (OPM Vet Guide, '5-Point Preference (TP)'). Based on your responses, it appears you may not meet this minimum service requirement for 5-point preference under this specific service path.
+To qualify for 5-point preference based on your service period and original enlistment/active duty start date (after Sep 7, 1980/Oct 14, 1982), you generally must have served continuously for 24 months OR the full period for which you were called or ordered to active duty, unless specific exceptions apply (like a separation for service-connected disability qualifying for 10-point preference, or a hardship separation). (OPM Vet Guide, section ['5-Point Preference (TP)']). Based on your responses, it appears you may not meet this minimum service requirement for 5-point preference under this specific service path.
 
 Choices:
 *   [Review service duration or exception choices.](./ownservice_tp_24month_duration.md)

--- a/advisor/ineligible_vow_discharge_type.md
+++ b/advisor/ineligible_vow_discharge_type.md
@@ -3,6 +3,6 @@ layout: default
 title: "Own Service (VOW Act): Ineligible - Discharge Not Expected to be Honorable"
 ---
 
-Veteran's preference requires eventual discharge or release under honorable conditions. If your VOW Act certification does not indicate an expected honorable discharge, you may not proceed with a claim for preference at this time under the VOW Act. (See OPM Vet Guide, 'A word about the VOW Act').
+Veteran's preference requires eventual discharge or release under honorable conditions. If your VOW Act certification does not indicate an expected honorable discharge, you may not proceed with a claim for preference at this time under the VOW Act. (See OPM Vet Guide, section ['A word about the VOW Act']).
 
 *   [Return to Advisor Start](./start.md)

--- a/advisor/ineligible_vow_retiredmajor_notdisabled.md
+++ b/advisor/ineligible_vow_retiredmajor_notdisabled.md
@@ -3,6 +3,6 @@ layout: default
 title: "Own Service (VOW Act): Ineligible - Retired Officer Not Disabled"
 ---
 
-Military retirees at the rank of Major, Lieutenant Commander, or higher are not eligible for preference unless they are disabled veterans. (OPM Vet Guide, 'Types of Preference'). Based on your responses, you may not be eligible for veteran's preference if you retire at this rank without a disability.
+Military retirees at the rank of Major, Lieutenant Commander, or higher are not eligible for preference unless they are disabled veterans. (OPM Vet Guide, section ['Types of Preference']). Based on your responses, you may not be eligible for veteran's preference if you retire at this rank without a disability.
 
 *   [Return to Advisor Start](./start.md)

--- a/advisor/ownservice_checkdisability_intro.md
+++ b/advisor/ownservice_checkdisability_intro.md
@@ -3,7 +3,7 @@ layout: default
 title: Veteran's Preference Advisor - Check for Service-Connected Disability or Purple Heart
 ---
 
-Next, we'll check if you might be eligible for 10-point preference. Do you have a service-connected disability recognized by the Department of Veterans Affairs (VA) or your branch of service, OR have you received a Purple Heart? (See OPM Vet Guide, '10-Point Disability Preference (XP)' for Purple Heart).
+Next, we'll check if you might be eligible for 10-point preference. Do you have a service-connected disability recognized by the Department of Veterans Affairs (VA) or your branch of service, OR have you received a Purple Heart? (See OPM Vet Guide, section ['10-Point Disability Preference (XP)'] for Purple Heart).
 
 * [Yes, I have a service-connected disability OR I received a Purple Heart.](./ownservice_disability_details.md)
 * [No.](./ownservice_discharged_checkfirst_solesurvivor.md)

--- a/advisor/ownservice_cp_details.md
+++ b/advisor/ownservice_cp_details.md
@@ -3,7 +3,7 @@ layout: default
 title: Own Service: 10-Point Preference (CP) - 10-20% Disability
 ---
 
-You indicated a service-connected disability rating of 10% or 20%. [cite_start]This generally qualifies you for 10-point Veteran's Preference (CP), provided your discharge was (or will be, if VOW Act applies) under honorable conditions and all other general eligibility requirements are met. [cite_start]For disabled veterans, active duty includes training service in the Reserves or National Guard. [cite_start]Remember to complete the SF-15 form.
+You indicated a service-connected disability rating of 10% or 20%. This generally qualifies you for 10-point Veteran's Preference (CP), provided your discharge was (or will be, if VOW Act applies) under honorable conditions and all other general eligibility requirements are met. For disabled veterans, active duty includes training service in the Reserves or National Guard. Remember to complete the SF-15 form.
 
 *   [Confirm, proceed to eligibility summary.](./eligible_cp_10point.md)
 *   [I made a mistake, review disability/Purple Heart options.](./ownservice_disability_details.md)

--- a/advisor/ownservice_cps_details.md
+++ b/advisor/ownservice_cps_details.md
@@ -3,7 +3,7 @@ layout: default
 title: Own Service: 10-Point Preference (CPS) - 30%+ Disability
 ---
 
-You indicated a service-connected disability rating of 30% or more. [cite_start]This generally qualifies you for 10-point Veteran's Preference (CPS), provided your discharge was (or will be, if VOW Act applies) under honorable conditions and all other general eligibility requirements are met. [cite_start]For disabled veterans, active duty includes training service in the Reserves or National Guard. [cite_start]Remember to complete the SF-15 form.
+You indicated a service-connected disability rating of 30% or more. This generally qualifies you for 10-point Veteran's Preference (CPS), provided your discharge was (or will be, if VOW Act applies) under honorable conditions and all other general eligibility requirements are met. For disabled veterans, active duty includes training service in the Reserves or National Guard. Remember to complete the SF-15 form.
 
 *   [Confirm, proceed to eligibility summary.](./eligible_cps_10point.md)
 *   [I made a mistake, review disability/Purple Heart options.](./ownservice_disability_details.md)


### PR DESCRIPTION
I've replaced internal citation tags (e.g., [cite: XXX]) with a standardized format referencing the OPM Vet Guide (e.g., (OPM Vet Guide, section [XXX])).

This change addresses Task 1.2 of plan.md. I processed approximately 50 files in the advisor directory to apply these changes. The new format aims for clearer and more direct sourcing of information presented in the Veteran's Preference Advisor tool.