### PR TITLE
Enhance advisor ineligible and eligible pages

### DIFF
--- a/advisor/eligible_cp_10point.md
+++ b/advisor/eligible_cp_10point.md
@@ -3,7 +3,7 @@ layout: default
 title: Veteran's Preference Advisor - Potential 10-Point Eligibility (CP)
 ---
 
-Based on your responses, you appear to meet the criteria for 10-point veteran's preference (CP) due to a service-connected disability rating of at least 10 percent but less than 30 percent. This is an initial assessment and not a final determination of preference.
+Based on your responses, you appear to meet the criteria for 10-point veteran's preference (CP) due to a service-connected disability rating of at least 10 percent but less than 30 percent. This is an initial assessment and not a final determination of preference. This preference means that 10 points are added to your passing score on a civil service examination. It also provides other benefits in the application process. (OPM Vet Guide, '10-Point Preference Due to Compensable Service-Connected Disability of Less Than 30 Percent (CP)')
 
 Key considerations for CP preference:
 * You must have been discharged or released from active duty under honorable conditions (or expect to be if applying under the VOW Act).
@@ -13,7 +13,5 @@ Key considerations for CP preference:
 
 Remember to claim preference when applying for Federal jobs and be prepared to provide documentation.
 
-Choices:
-* "Learn more about applying with 10-point preference (SF-15)" (Link to OPM guidance on SF-15 or a future detailed info page)
-* "[Return to Advisor Start](./start.md)"
-```
+* [Learn more about the SF-15 (Application for 10-Point Veteran Preference)]({{ site.baseurl }}/advisor/sf15_information.md)
+* [Return to Advisor Start]({{ site.baseurl }}/advisor/start.md)

--- a/advisor/eligible_cps_10point.md
+++ b/advisor/eligible_cps_10point.md
@@ -3,7 +3,7 @@ layout: default
 title: Veteran's Preference Advisor - Potential 10-Point Eligibility (CPS)
 ---
 
-Based on your responses, you appear to meet the criteria for 10-point veteran's preference (CPS) due to a service-connected disability rating of 30 percent or more. This is an initial assessment and not a final determination of preference.
+Based on your responses, you appear to meet the criteria for 10-point veteran's preference (CPS) due to a service-connected disability rating of 30 percent or more. This is an initial assessment and not a final determination of preference. This preference means that 10 points are added to your passing score on a civil service examination. Importantly, CPS eligibility may also allow you to be considered for certain positions non-competitively. (OPM Vet Guide, '10-Point Preference Due to Compensable Service-Connected Disability of 30 Percent or More (CPS)')
 
 Key considerations for CPS preference:
 * You must have been discharged or released from active duty under honorable conditions (or expect to be if applying under the VOW Act).
@@ -13,7 +13,5 @@ Key considerations for CPS preference:
 
 Remember to claim preference when applying for Federal jobs and be prepared to provide documentation.
 
-Choices:
-* "Learn more about applying with 10-point preference (SF-15)" (Link to OPM guidance on SF-15 or a future detailed info page)
-* "[Return to Advisor Start](./start.md)"
-```
+* [Learn more about the SF-15 (Application for 10-Point Veteran Preference)]({{ site.baseurl }}/advisor/sf15_information.md)
+* [Return to Advisor Start]({{ site.baseurl }}/advisor/start.md)

--- a/advisor/eligible_tp_5point.md
+++ b/advisor/eligible_tp_5point.md
@@ -3,9 +3,7 @@ title: "Veteran's Preference Advisor - Potential 5-Point Eligibility (TP)"
 layout: default
 ---
 
-Based on your responses, you appear to meet the criteria for 5-point veteran's preference (TP), provided your discharge was (or will be, if VOW Act applies) under honorable conditions and all other general eligibility requirements are met. This is an initial assessment and not a final determination of preference. Remember to claim preference when applying for Federal jobs and be prepared to provide necessary documentation (like your DD Form 214 or VOW Act certification).
+Based on your responses, you appear to meet the criteria for 5-point veteran's preference (TP), provided your discharge was (or will be, if VOW Act applies) under honorable conditions and all other general eligibility requirements are met. This is an initial assessment and not a final determination of preference. This preference means that 5 points are added to your passing score on a civil service examination. (OPM Vet Guide, '5-Point Preference (TP)') Remember to claim preference when applying for Federal jobs and be prepared to provide necessary documentation (like your DD Form 214 or VOW Act certification).
 
-Choices:
-*   [Learn more about what to do next](./#) <!-- Placeholder link -->
-*   [Return to Advisor Start](./start.md)
-```
+* [Understanding how to claim your preference on USAJOBS](https://www.usajobs.gov/help/faq/application/veterans-preference/) (External Link)
+* [Return to Advisor Start]({{ site.baseurl }}/advisor/start.md)

--- a/advisor/eligible_xp_10point.md
+++ b/advisor/eligible_xp_10point.md
@@ -3,7 +3,7 @@ layout: default
 title: Veteran's Preference Advisor - Potential 10-Point Eligibility (XP)
 ---
 
-Based on your responses, you appear to meet the criteria for 10-point veteran's preference (XP). This is an initial assessment and not a final determination of preference.
+Based on your responses, you appear to meet the criteria for 10-point veteran's preference (XP). This is an initial assessment and not a final determination of preference. This preference means that 10 points are added to your passing score on a civil service examination. (OPM Vet Guide, '10-Point Preference Other Than CP or CPS (XP)')
 
 Key considerations for XP preference:
 * It can be based on receiving a Purple Heart OR having a service-connected disability (or receiving compensation/pension for it) that doesn't fall into the specific CP (10-20%) or CPS (30%+) categories.
@@ -14,7 +14,5 @@ Key considerations for XP preference:
 
 Remember to claim preference when applying for Federal jobs and be prepared to provide documentation.
 
-Choices:
-* "Learn more about applying with 10-point preference (SF-15)" (Link to OPM guidance on SF-15 or a future detailed info page)
-* "[Return to Advisor Start](./start.md)"
-```
+* [Learn more about the SF-15 (Application for 10-Point Veteran Preference)]({{ site.baseurl }}/advisor/sf15_information.md)
+* [Return to Advisor Start]({{ site.baseurl }}/advisor/start.md)

--- a/advisor/eligible_xp_derived_mother.md
+++ b/advisor/eligible_xp_derived_mother.md
@@ -3,12 +3,12 @@ layout: default
 title: Veteran's Preference Advisor - Potential 10-Point Derived Preference (XP) - Mother
 ---
 
-Based on your responses, you appear to meet the criteria for 10-point derived veteran's preference (XP) as the mother of a qualifying veteran (either deceased under specific conditions or living and permanently and totally disabled from a service-connected cause).
+Based on your responses, you appear to meet the criteria for 10-point derived veteran's preference (XP) as the mother of a qualifying veteran (either deceased under specific conditions or living and permanently and totally disabled from a service-connected cause). This preference means that 10 points are added to your passing score on a civil service examination if you are found eligible. (OPM Vet Guide, 'Mother of a Deceased Veteran or of a Living Disabled Veteran (XP)')
 
 This is an initial assessment and not a final determination of preference. Remember to:
 * Claim preference when applying for Federal jobs.
 * Complete the Standard Form (SF) 15, Application for 10-Point Veteran Preference.
 * Be prepared to provide necessary documentation (e.g., veteran's birth certificate listing you as mother, proof of your marriage to veteran's father, veteran's proof of service/disability/death as applicable, documentation for your current marital/living status).
 
-* `"Learn more about applying with 10-point preference (SF-15)"` (Link to OPM guidance on SF-15 or a future detailed info page)
-* `[Return to Advisor Start]` -> `start.md`
+* [Learn more about the SF-15 (Application for 10-Point Veteran Preference)]({{ site.baseurl }}/advisor/sf15_information.md)
+* [Return to Advisor Start]({{ site.baseurl }}/advisor/start.md)

--- a/advisor/eligible_xp_derived_spouse.md
+++ b/advisor/eligible_xp_derived_spouse.md
@@ -3,12 +3,12 @@ layout: default
 title: Veteran's Preference Advisor - Potential 10-Point Derived Preference (XP) - Spouse
 ---
 
-Based on your responses, you appear to meet the criteria for 10-point derived veteran's preference (XP) as the spouse of a veteran who is disqualified for a Federal position along the general lines of his or her usual occupation because of a service-connected disability (OPM Vet Guide, sections [132, 133, 134, 135]).
+Based on your responses, you appear to meet the criteria for 10-point derived veteran's preference (XP) as the spouse of a veteran who is disqualified for a Federal position along the general lines of his or her usual occupation because of a service-connected disability (OPM Vet Guide, sections [132, 133, 134, 135]). If approved, this preference means 10 points are added to your passing score on a civil service examination.
 
 This is an initial assessment and not a final determination of preference. Remember to:
 * Claim preference when applying for Federal jobs.
 * Complete the Standard Form (SF) 15, Application for 10-Point Veteran Preference.
 * Be prepared to provide necessary documentation (e.g., marriage certificate, veteran's proof of service-connected disability and unemployability/disqualification for usual occupation).
 
-* `"Learn more about applying with 10-point preference (SF-15)"` (Link to OPM guidance on SF-15 or a future detailed info page)
-* `[Return to Advisor Start]` -> `start.md`
+* [Learn more about the SF-15 (Application for 10-Point Veteran Preference)]({{ site.baseurl }}/advisor/sf15_information.md)
+* [Return to Advisor Start]({{ site.baseurl }}/advisor/start.md)

--- a/advisor/eligible_xp_derived_spouse_conditional.md
+++ b/advisor/eligible_xp_derived_spouse_conditional.md
@@ -3,7 +3,7 @@ layout: default
 title: Veteran's Preference Advisor - Potential Conditional 10-Point Derived Preference (XP) - Spouse
 ---
 
-Based on your responses, you *may* meet the criteria for 10-point derived veteran's preference (XP) as the spouse of a veteran disqualified for their usual occupation due to a service-connected disability.
+Based on your responses, you *may* meet the criteria for 10-point derived veteran's preference (XP) as the spouse of a veteran disqualified for their usual occupation due to a service-connected disability. If your application for preference is approved after this careful analysis, it means 10 points would be added to your passing score on a civil service examination.
 
 However, because your situation does not fall under the standard presumptions for disqualification, your claim will require a more careful analysis by the hiring agency, and possibly OPM (OPM Vet Guide, section [136]).
 
@@ -13,5 +13,5 @@ Key reminders:
 
 This is an initial assessment and not a final determination of preference.
 
-*   `"Learn more about applying with 10-point preference (SF-15)"` #(Link to OPM guidance on SF-15 or a future detailed info page)
-*   `"[Return to Advisor Start]"` -> `start.md`
+* [Learn more about the SF-15 (Application for 10-Point Veteran Preference)]({{ site.baseurl }}/advisor/sf15_information.md)
+* [Return to Advisor Start]({{ site.baseurl }}/advisor/start.md)

--- a/advisor/eligible_xp_derived_widow.md
+++ b/advisor/eligible_xp_derived_widow.md
@@ -3,12 +3,12 @@ layout: default
 title: Veteran's Preference Advisor - Potential 10-Point Derived Preference (XP) - Widow/Widower
 ---
 
-Based on your responses, you appear to meet the criteria for 10-point derived veteran's preference (XP) as the widow/widower of a qualifying veteran (OPM Vet Guide, sections [139, 140]).
+Based on your responses, you appear to meet the criteria for 10-point derived veteran's preference (XP) as the widow/widower of a qualifying veteran (OPM Vet Guide, sections [139, 140]). If approved, this preference means 10 points are added to your passing score on a civil service examination.
 
 This is an initial assessment and not a final determination of preference. Remember to:
 * Claim preference when applying for Federal jobs.
 * Complete the Standard Form (SF) 15, Application for 10-Point Veteran Preference.
 * Be prepared to provide necessary documentation (e.g., marriage certificate, veteran's death certificate, veteran's proof of qualifying service).
 
-* `"Learn more about applying with 10-point preference (SF-15)"` (Link to OPM guidance on SF-15 or a future detailed info page)
-* `[Return to Advisor Start]` -> `start.md`
+* [Learn more about the SF-15 (Application for 10-Point Veteran Preference)]({{ site.baseurl }}/advisor/sf15_information.md)
+* [Return to Advisor Start]({{ site.baseurl }}/advisor/start.md)

--- a/advisor/ineligible_derived_mother_currentmarital.md
+++ b/advisor/ineligible_derived_mother_currentmarital.md
@@ -9,6 +9,8 @@ To be eligible for derived preference as a mother, your current marital and livi
 
 Based on your response (currently married and husband is not P&T disabled), you may not meet these conditions.
 
-* `[Return to check current marital/living status]` -> `derived_mother_common_currentmarital.md`
-* `[Return to Relationship Choice]` -> `derived_intro.md`
-* `[Return to Advisor Start]` -> `start.md`
+If your situation is complex or not clearly covered by these options, you may want to consult the OPM Vet Guide directly or seek assistance from a Veterans Service Organization.
+
+* [Return to check current marital/living status]({{ site.baseurl }}/advisor/derived_mother_common_currentmarital.md)
+* [Return to Relationship Choice]({{ site.baseurl }}/advisor/derived_intro.md)
+* [Return to Advisor Start]({{ site.baseurl }}/advisor/start.md)

--- a/advisor/ineligible_derived_widow_divorced.md
+++ b/advisor/ineligible_derived_widow_divorced.md
@@ -6,6 +6,6 @@ title: Derived Preference (Widow/Widower): Potentially Ineligible - Divorced
 
 To be eligible for derived preference as a widow or widower, you must not have been divorced from the veteran at the time of their death (OPM Vet Guide, section [139]). Based on your response, you may not be eligible.
 
-* [Return to check marital status at death](./derived_widow_divorced.md)
-* [Return to Relationship Choice](./derived_intro.md)
-* [Return to Advisor Start](./start.md)
+* [Return to check marital status at death]({{ site.baseurl }}/advisor/derived_widow_divorced.md)
+* [Return to Relationship Choice]({{ site.baseurl }}/advisor/derived_intro.md)
+* [Return to Advisor Start]({{ site.baseurl }}/advisor/start.md)

--- a/advisor/ineligible_derived_widow_remarried.md
+++ b/advisor/ineligible_derived_widow_remarried.md
@@ -6,6 +6,6 @@ title: Derived Preference (Widow/Widower): Potentially Ineligible - Remarried
 
 To be eligible for derived preference as a widow or widower, you must not have remarried since the veteran's death, or if you remarried, that subsequent marriage must have been annulled (OPM Vet Guide, section [139]). Based on your response, you may not be eligible.
 
-* [Return to check remarriage status](./derived_widow_remarried.md)
-* [Return to Relationship Choice](./derived_intro.md)
-* [Return to Advisor Start](./start.md)
+* [Return to check remarriage status]({{ site.baseurl }}/advisor/derived_widow_remarried.md)
+* [Return to Relationship Choice]({{ site.baseurl }}/advisor/derived_intro.md)
+* [Return to Advisor Start]({{ site.baseurl }}/advisor/start.md)

--- a/advisor/ineligible_derived_widow_vetservicenotqualifying.md
+++ b/advisor/ineligible_derived_widow_vetservicenotqualifying.md
@@ -8,6 +8,6 @@ For derived preference as a widow/widower, the veteran's service generally must 
 
 Preference is generally not granted to widows or mothers if the deceased veteran's own preference eligibility was based *only* on other criteria (e.g., service after 1955 that was not in a war or campaign, such as >180 days of active duty or Gulf War service without a specific campaign medal) (OPM Vet Guide, section [152]). Based on your response, the veteran's service may not qualify for this type of derived preference.
 
-* [Return to check veteran's service conditions](./derived_widow_vetservice_condition.md)
-* [Return to Relationship Choice](./derived_intro.md)
-* [Return to Advisor Start](./start.md)
+* [Return to check veteran's service conditions]({{ site.baseurl }}/advisor/derived_widow_vetservice_condition.md)
+* [Return to Relationship Choice]({{ site.baseurl }}/advisor/derived_intro.md)
+* [Return to Advisor Start]({{ site.baseurl }}/advisor/start.md)

--- a/advisor/ineligible_discharge_type.md
+++ b/advisor/ineligible_discharge_type.md
@@ -5,4 +5,5 @@ title: "Own Service: Ineligible - Discharge Not Under Honorable Conditions"
 
 Veteran's preference requires a discharge or release under honorable conditions (i.e., an Honorable or General discharge). (OPM Vet Guide, section ['Types of Preference']). If your discharge was of a different character, you may not be eligible.
 
-*   [Return to Advisor Start](./start.md)
+* [Re-check discharge character]({{ site.baseurl }}/advisor/ownservice_discharged_honorableconditions.md)
+* [Return to Advisor Start]({{ site.baseurl }}/advisor/start.md)

--- a/advisor/ineligible_general.md
+++ b/advisor/ineligible_general.md
@@ -5,4 +5,5 @@ title: Veteran's Preference Advisor - Initial Ineligibility
 
 Based on your initial selection, it appears you may not be directly pursuing veteran's preference based on your own service or as a qualifying relative (spouse, widow(er), mother) of a veteran. This advisor focuses on those categories. Veteran's preference is a specific entitlement for those who served in the Armed Forces during certain periods or campaigns, or have service-connected disabilities, and for certain family members (see OPM Vet Guide, section ['Why Preference is Given']).
 
-*   [Return to Advisor Start](./start.md)
+* [Learn more about Veteran's Preference at OPM.gov](https://www.opm.gov/policy-data-oversight/veterans-services/vet-guide-for-hr-professionals/)
+* [Return to Advisor Start]({{ site.baseurl }}/advisor/start.md)

--- a/advisor/ineligible_ownservice_status.md
+++ b/advisor/ineligible_ownservice_status.md
@@ -3,7 +3,8 @@ layout: default
 title: Ineligible Based on Current Service Status
 ---
 
-Based on your responses, you do not currently meet the preliminary requirements for veteran's preference. Generally, you must be discharged or released from active duty under honorable conditions to be eligible. If you are still on active duty, you may be eligible under the VOW Act if you are within 120 days of discharge and can provide a certification. <!-- TODO: Add link to VOW Act info or back to VOW questions if applicable --> For more information, please review the OPM Vet Guide (OPM Vet Guide, section [Appendix A - Definitions of Terms and Categories, Page 31]).
+Based on your responses, you do not currently meet the preliminary requirements for veteran's preference. Generally, you must be discharged or released from active duty under honorable conditions to be eligible. If you are still on active duty, you may be eligible under the VOW Act if you are within 120 days of discharge and can provide a certification. For more information, please review the OPM Vet Guide (OPM Vet Guide, section [Appendix A - Definitions of Terms and Categories, Page 31]).
 
-*   [I made a mistake in my previous answers, take me back.](./ownservice_intro.md)
-*   [Return to Advisor Start](./start.md)
+* [Learn more about VOW Act eligibility requirements]({{ site.baseurl }}/advisor/ownservice_intro.md)
+* [I made a mistake in my previous answers, take me back.]({{ site.baseurl }}/advisor/ownservice_intro.md)
+* [Return to Advisor Start]({{ site.baseurl }}/advisor/start.md)

--- a/advisor/ineligible_retiredmajor_notdisabled.md
+++ b/advisor/ineligible_retiredmajor_notdisabled.md
@@ -5,4 +5,5 @@ title: "Own Service: Ineligible - Retired Officer Not Disabled"
 
 Military retirees at the rank of Major, Lieutenant Commander, or higher are not eligible for preference in appointment unless they are disabled veterans. (OPM Vet Guide, section ['Types of Preference']). Based on your responses, you may not be eligible for veteran's preference under this condition.
 
-*   [Return to Advisor Start](./start.md)
+* [Re-check retirement/disability status]({{ site.baseurl }}/advisor/ownservice_discharged_checkretired.md)
+* [Return to Advisor Start]({{ site.baseurl }}/advisor/start.md)

--- a/advisor/ineligible_vow_discharge_type.md
+++ b/advisor/ineligible_vow_discharge_type.md
@@ -5,4 +5,5 @@ title: "Own Service (VOW Act): Ineligible - Discharge Not Expected to be Honorab
 
 Veteran's preference requires eventual discharge or release under honorable conditions. If your VOW Act certification does not indicate an expected honorable discharge, you may not proceed with a claim for preference at this time under the VOW Act. (See OPM Vet Guide, section ['A word about the VOW Act']).
 
-*   [Return to Advisor Start](./start.md)
+* [Re-check VOW certification details]({{ site.baseurl }}/advisor/ownservice_vow_honorableconditions.md)
+* [Return to Advisor Start]({{ site.baseurl }}/advisor/start.md)

--- a/advisor/ineligible_vow_retiredmajor_notdisabled.md
+++ b/advisor/ineligible_vow_retiredmajor_notdisabled.md
@@ -5,4 +5,5 @@ title: "Own Service (VOW Act): Ineligible - Retired Officer Not Disabled"
 
 Military retirees at the rank of Major, Lieutenant Commander, or higher are not eligible for preference unless they are disabled veterans. (OPM Vet Guide, section ['Types of Preference']). Based on your responses, you may not be eligible for veteran's preference if you retire at this rank without a disability.
 
-*   [Return to Advisor Start](./start.md)
+* [Re-check retirement/disability status (VOW path)]({{ site.baseurl }}/advisor/ownservice_vow_checkretired.md)
+* [Return to Advisor Start]({{ site.baseurl }}/advisor/start.md)


### PR DESCRIPTION
This commit implements the following changes:
- Reviewed and updated all `ineligible_*.md` pages:
    - Ensured clear statement of ineligibility reasons.
    - Added/improved guidance for you to re-evaluate answers or explore alternative paths.
    - Standardized link formats to use `{{ site.baseurl }}`.
    - Addressed specific TODOs and improved navigation links.
- Reviewed and updated all `eligible_*.md` pages:
    - Ensured clear statement of preference type (e.g., TP, CP, CPS, XP).
    - Added brief summaries of key entitlements (e.g., points added, non-competitive consideration for CPS).
    - Clarified next steps for you.
    - Standardized and enhanced information about the SF-15 form for all 10-point preference pages, including a consistent link to a placeholder `sf15_information.md` page.
    - Added OPM Vet Guide citations where appropriate.
    - Standardized link formats.