### PR TITLE
Create SF-15 informational page and update links

### DIFF
--- a/advisor/sf15_information.md
+++ b/advisor/sf15_information.md
@@ -1,0 +1,35 @@
+---
+layout: default
+title: Understanding the SF-15, Application for 10-Point Veteran Preference
+---
+
+## Understanding the SF-15: Application for 10-Point Veteran Preference
+
+The Standard Form 15 (SF-15) is an official government form used by federal agencies to adjudicate claims for 10-point veteran preference. If you are claiming 10-point preference as a disabled veteran or as an eligible relative (e.g., spouse, widow/widower, or mother of a veteran), you will likely need to complete and submit this form along with required supporting documentation.
+
+### Why is the SF-15 Necessary?
+
+Veteran's preference provides a significant advantage in federal hiring. The 10-point preference, in particular, is granted for specific categories, often involving disability or derived rights. The SF-15:
+
+*   **Standardizes Claims:** It provides a consistent way for applicants to claim 10-point preference.
+*   **Details Eligibility:** It outlines the specific criteria for each type of 10-point preference (e.g., compensable service-connected disability, Purple Heart recipient, spouse/widow/mother of a qualifying veteran).
+*   **Lists Required Documentation:** The form specifies the documents you must submit to prove your eligibility (e.g., DD Form 214, VA disability rating letter, marriage certificate, veteran's death certificate). This is crucial, as your claim cannot be approved without proper proof.
+
+### Who Needs to Fill Out the SF-15?
+
+You will generally need to fill out the SF-15 if you are applying for a federal job and claiming:
+
+*   **10-Point Preference for your own service:** This includes preference based on a service-connected disability (CP or CPS) or other qualifying conditions (XP, such as being a Purple Heart recipient).
+*   **10-Point Derived Preference:** This applies if you are a spouse, widow/widower, or mother of a veteran whose service forms the basis of your claim.
+
+**Note:** While 5-point preference also requires documentation (usually your DD Form 214), the SF-15 is specifically for 10-point claims.
+
+### Where to Get the SF-15
+
+You can download the official SF-15 form from the U.S. Office of Personnel Management (OPM) website. It's important to use the latest version of the form.
+
+*   **[Download SF-15 from OPM.gov](https://www.opm.gov/forms/pdf_fill/sf15.pdf)**
+
+When completing the SF-15, read the instructions carefully and ensure all information is accurate and all required documents are attached. Submitting an incomplete or incorrect SF-15 can delay the processing of your application.
+
+*   [Return to Advisor Start]({{ site.baseurl }}/advisor/start.md)


### PR DESCRIPTION
This commit introduces a new page, advisor/sf15_information.md, which provides you with details about the Standard Form 15 (Application for 10-Point Veteran Preference).

The page explains:
- What the SF-15 is.
- Why it's necessary for 10-point preference claims.
- Who needs to complete it.
- A direct link to the official SF-15 PDF on OPM.gov.

Links in existing eligibility pages (e.g., eligible_cp_10point.md, eligible_xp_10point.md, etc.) already pointed to this new page's location, and these are now functional. This addresses Task 1.5 of the project plan.