### PR TITLE
Fix: Improve mobile responsiveness and readability

### DIFF
--- a/_sass/jekyll-theme-minimal.scss
+++ b/_sass/jekyll-theme-minimal.scss
@@ -4,7 +4,7 @@
 body {
   background-color: #fff;
   padding:50px;
-  font: 14px/1.5 "Noto Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font: 16px/1.6 "Noto Sans", "Helvetica Neue", Helvetica, Arial, sans-serif; // MODIFIED
   color:#727272;
   font-weight:400;
 }
@@ -210,6 +210,16 @@ footer {
   -webkit-font-smoothing:subpixel-antialiased;
 }
 
+// ADDITION: Improve tap targets for links in lists
+section ul li a {
+  display: inline-block;
+  padding: 8px 5px;
+}
+
+section ul li {
+  margin-bottom: 5px;
+}
+
 @media print, screen and (max-width: 960px) {
 
   div.wrapper {
@@ -248,6 +258,7 @@ footer {
 @media print, screen and (max-width: 720px) {
   body {
     word-wrap:break-word;
+    font-size: 15px; // ADDED
   }
 
   header {
@@ -260,6 +271,11 @@ footer {
 
   pre, code {
     word-wrap:normal;
+  }
+
+  // ADDED
+  section ul li a {
+    padding: 10px 5px;
   }
 }
 
@@ -274,6 +290,16 @@ footer {
 
   .downloads li, .downloads li + li + li {
     width:33%;
+  }
+
+  // ADDED
+  section ul li a {
+    font-size: 1.05em;
+    padding: 12px 6px;
+  }
+  // ADDED
+  section ul li {
+    margin-bottom: 8px;
   }
 }
 


### PR DESCRIPTION
This commit addresses task 2.3 of the project plan.

The following changes were made to `_sass/jekyll-theme-minimal.scss`:
- Increased the base body font size from 14px to 16px for better overall readability.
- Adjusted line height for improved text flow.
- Added padding to links within lists in sections to increase tap target size, particularly beneficial for mobile users.
- Added margin between list items in sections for better visual separation.
- Implemented media queries to fine-tune font sizes and padding for tablet and mobile screen sizes, ensuring a good user experience across devices.

I tested these changes by reviewing the advisor flow and content pages on simulated desktop, tablet, and mobile views. The updates enhance the site's usability on smaller screens.