### PR TITLE
Add FAQ page based on OPM Vet Guide

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -1,0 +1,82 @@
+# Frequently Asked Questions
+
+This page answers common questions about Veteran's Preference in federal hiring. The information is based on the OPM Vet Guide for HR Professionals.
+
+## How is "war" defined for preference purposes?
+
+For veteran's preference purposes, "war" means only those armed conflicts declared by Congress as war. This includes World War II (December 7, 1941, to April 28, 1952). Title 38 U.S.C. defines "period of war" to include many non-declared wars for VA benefits, but this definition is NOT applicable for civil service preference purposes. (OPM Vet Guide, 'Introduction')
+
+## What's the difference between 5-point and 10-point preference?
+
+When using a numerical ranking process for competitive examinations, eligible veterans can have 5 or 10 points added to their passing examination score or rating.
+
+**5-Point Preference (TP):** Five points are added for veterans who served:
+* During a war; or
+* During the period April 28, 1952 through July 1, 1955; or
+* For more than 180 consecutive days (other than for training) any part of which occurred after January 31, 1955, and before October 15, 1976; or
+* During the Gulf War from August 2, 1990, through January 2, 1992; or
+* For more than 180 consecutive days (other than for training) any part of which occurred during the period beginning September 11, 2001, and ending on August 31, 2010 (last day of Operation Iraqi Freedom); or
+* In a campaign or expedition for which a campaign medal has been authorized.
+
+A campaign medal holder or Gulf War veteran who originally enlisted after September 7, 1980, (or began active duty on or after October 14, 1982, and has not previously completed 24 months of continuous active duty) must have served continuously for 24 months or the full period called or ordered to active duty. This 24-month requirement does not apply to 10-point preference eligibles separated for disability or hardship.
+
+**10-Point Preference:** Ten points are added for:
+* **Compensable Disability Preference (CP):** Veterans with a compensable service-connected disability rating of at least 10% but less than 30%.
+* **30 Percent Compensable Disability Preference (CPS):** Veterans with a compensable service-connected disability rating of 30% or more.
+* **Disability Preference (XP):** Veterans with a present service-connected disability or receiving compensation, disability retirement benefits, or pension from the military or VA (who don't qualify as CP or CPS), or veterans who received a Purple Heart.
+* **Derived Preference (XP):** Spouses, widows, widowers, or mothers of veterans under specific conditions, as this preference is derived from a veteran unable to use it.
+
+Applicants claiming 10-point preference must complete Standard Form (SF) 15, Application for 10-Point Veteran Preference, and submit required documentation. (OPM Vet Guide, 'Types of Preference')
+
+## How does preference apply in Reductions in Force (RIF)?
+
+Veterans have advantages over non-veterans in a Reduction in Force (RIF). Employees are ranked on retention registers based on tenure, veteran's preference, length of service, and performance.
+
+Within each tenure group (I, II, or III), employees are placed in subgroups:
+* **Subgroup AD:** Preference eligibles with a compensable service-connected disability of 30% or more.
+* **Subgroup A:** All other preference eligibles (including derived preference).
+* **Subgroup B:** Non-preference eligibles.
+
+Within each subgroup, employees are ranked by length of creditable service, augmented by performance ratings. Because veterans are listed ahead of non-veterans within each tenure group, they are the last to be affected by a RIF.
+
+Special provisions apply to retired military members regarding preference eligibility and service credit in RIFs. (OPM Vet Guide, 'Veterans' Preference in Reduction in Force')
+
+## What if I don't have my DD Form 214?
+
+The VOW (Veterans Opportunity to Work) to Hire Heroes Act of 2011 allows active duty service members who are within 120 days of discharge to apply for federal jobs using a "certification" in lieu of a DD Form 214.
+
+A "certification" is any written document from the armed forces that certifies the service member is expected to be discharged or released from active duty service under honorable conditions within 120 days after the certification is submitted. The certification letter should be on letterhead of the appropriate military branch and contain (1) the military service dates including the expected discharge or release date; and (2) the character of service.
+
+Agencies are required to accept, process, and grant tentative veterans’ preference to those active duty service members who submit such a certification. However, agencies must verify the individual meets the definition of ‘preference eligible’ under 5 U.S.C. 2108 prior to appointment, which may involve providing the DD Form 214 after it is issued.
+
+If an applicant is claiming preference based on service (e.g., in Bosnia) and does not have a DD Form 214 to support the claim, tentative preference may be accorded, but proof of entitlement (like an amended DD Form 214 or other official documentation) must be submitted before appointment. (OPM Vet Guide, 'A word about the VOW (Veterans Opportunity to Work) Act' and 'Questions and Answers about Gulf War Preference')
+
+## What is "derived preference"?
+
+Derived preference (a type of 10-point XP preference) is granted to spouses, widows, widowers, or mothers of veterans under specific circumstances. This preference is "derived" because it's based on the service of a veteran who is unable to use the preference themselves.
+
+Eligibility for derived preference depends on factors such as:
+* **For a spouse:** The veteran must be disqualified for a federal position along the lines of their usual occupation due to a service-connected disability (e.g., rated 100% disabled/unemployable, retired from civil service due to service-connected disability, or failed to qualify for jobs due to it).
+* **For a widow/widower:** The veteran must not have been divorced from the individual, the individual must not have remarried (or the remarriage was annulled), and the veteran's service must meet certain criteria (e.g., served during a war, specific periods, or in a campaign for which a medal was authorized, or died on active duty under qualifying conditions).
+* **For a mother of a deceased veteran:** The veteran must have died under honorable conditions on active duty during specific periods or campaigns, and the mother must meet certain marital and dependency criteria (e.g., lives with her totally and permanently disabled husband, or is widowed/divorced and not remarried).
+* **For a mother of a living disabled veteran:** The veteran must have been separated honorably and be permanently and totally disabled from a service-connected injury/illness, and the mother must meet similar marital and dependency criteria as for the mother of a deceased veteran.
+
+Both a mother and a spouse may be entitled to preference based on the same veteran's service if they both meet the requirements. However, neither may receive preference if the veteran is living and qualified for federal employment. (OPM Vet Guide, '10-Point Derived Preference (XP)')
+
+## Does preference apply to all federal jobs?
+
+No, preference does not apply to all federal jobs.
+
+**Preference DOES apply to:**
+* Permanent and temporary positions in the competitive and excepted services of the executive branch.
+* Hiring from civil service examinations conducted by OPM and agencies under delegated examining authority.
+* Most excepted service jobs, including Veterans Recruitment Appointments (VRA).
+* When agencies make temporary, term, and overseas limited appointments.
+
+**Preference DOES NOT apply to:**
+* Positions in the Senior Executive Service (SES).
+* Executive branch positions for which Senate confirmation is required.
+* Positions in the legislative and judicial branches of the Federal Government, unless the positions are in the competitive service (e.g., Government Printing Office) or have been made subject to the Veterans' Preference Act by another law.
+* Promotions, reassignments, changes to lower grade, transfers, or reinstatements.
+
+Agencies have broad authority to hire from any appropriate source of eligibles, including special appointing authorities, and are required to give priority to displaced employees before using civil service examinations. (OPM Vet Guide, 'When Preference Applies')


### PR DESCRIPTION
This commit introduces a new `faq.md` page.
The page addresses common questions veterans might have regarding veteran's preference in federal hiring.

The content is derived from the OPM Vet Guide for HR Professionals and covers:
- Definition of "war" for preference purposes.
- Difference between 5-point and 10-point preference.
- Application of preference in Reductions in Force (RIF).
- Procedures for applicants without a DD Form 214 (VOW Act).
- Explanation of "derived preference."
- Scope of jobs to which preference applies.