### PR TITLE
Fix broken links in advisor markdown file

### DIFF
--- a/advisor/ownservice_checkdisability_intro.md
+++ b/advisor/ownservice_checkdisability_intro.md
@@ -14,6 +14,6 @@ The OPM Vet Guide for HR Professionals outlines several categories for 10-point 
 
 Do you have a service-connected disability recognized by the Department of Veterans Affairs (VA) or your branch of service, OR have you received a Purple Heart?
 
-*   `"Yes, I have a service-connected disability OR I received a Purple Heart."` -> `ownservice_disability_details.md`
-*   `"No, I do not have a service-connected disability and did not receive a Purple Heart."` -> `ownservice_discharged_checkfirst_solesurvivor.md` (This will then check for Sole Survivorship)
-*   `"[Return to Advisor Start]"` -> `start.md`
+*   ["Yes, I have a service-connected disability OR I received a Purple Heart."](./ownservice_disability_details.md)
+*   ["No, I do not have a service-connected disability and did not receive a Purple Heart."](./ownservice_discharged_checkfirst_solesurvivor.md) (This will then check for Sole Survivorship)
+*   ["[Return to Advisor Start]"](./start.md)


### PR DESCRIPTION
The links in advisor/ownservice_checkdisability_intro.md were not proper markdown links. I've converted them to the correct format.