### PR TITLE
Standardize formatting for advisor pages

### DIFF
--- a/advisor/derived_mother_clarify_currentmarital.md
+++ b/advisor/derived_mother_clarify_currentmarital.md
@@ -7,11 +7,11 @@ title: "Mother's Preference: Clarification on Current Marital/Living Status"
 
 You've requested clarification on the marital and living status requirements for a mother's derived preference. These conditions are a crucial part of determining eligibility and apply whether the veteran is deceased or living and disabled. Understanding these rules are essential for correctly claiming this benefit.
 
-The OPM Vet Guide for HR Professionals states that, in addition to the primary condition that the mother *"is or was married to the father of the veteran"*, she must also meet **one** of the following conditions at the time she claims preference:
+The OPM Vet Guide for HR Professionals states that, in addition to the primary condition that the mother > "is or was married to the father of the veteran", she must also meet **one** of the following conditions at the time she claims preference:
 
-*   *"she lives with her totally and permanently disabled husband (either the veteran's father or her husband through remarriage); or"*
-*   *"she is widowed, divorced, or separated from the veteran's father and has not remarried; or"*
-*   *"she remarried but is widowed, divorced, or legally separated from her husband when she claims preference."*
+> *   *"she lives with her totally and permanently disabled husband (either the veteran's father or her husband through remarriage); or"*
+> *   *"she is widowed, divorced, or separated from the veteran's father and has not remarried; or"*
+> *   *"she remarried but is widowed, divorced, or legally separated from her husband when she claims preference."*
 
 **Explanation of these conditions:**
 
@@ -38,5 +38,5 @@ The OPM Vet Guide for HR Professionals states that, in addition to the primary c
 
 If your situation is complex, it is highly recommended to consult the full text in the "10-Point Derived Preference (XP)" section of the OPM Vet Guide for HR Professionals, specifically under "Mother of a deceased veteran" or "Mother of a disabled veteran," and review your SF-15 documentation. This advisor aims to clarify but cannot cover every unique circumstance.
 
-*   [Return to current marital/living status choices](./derived_mother_common_currentmarital.md)
-*   [Return to Advisor Start](./start.md)
+*   [**Return to current marital/living status choices**](./derived_mother_common_currentmarital.md)
+*   [**Return to Advisor Start**](./start.md)

--- a/advisor/derived_mother_common_currentmarital.md
+++ b/advisor/derived_mother_common_currentmarital.md
@@ -20,9 +20,9 @@ A mother may be eligible for preference if her living veteran child was separate
 ### Marital Status Conditions
 
 For both scenarios, the mother must also meet one of the following conditions at the time she claims preference:
-*   She *"lives with her totally and permanently disabled husband (either the veteran's father or her husband through remarriage); or"*
-*   She *"is widowed, divorced, or separated from the veteran's father and has not remarried; or"*
-*   She *"remarried but is widowed, divorced, or legally separated from her husband when she claims preference."*
+> *   She *"lives with her totally and permanently disabled husband (either the veteran's father or her husband through remarriage); or"*
+> *   She *"is widowed, divorced, or separated from the veteran's father and has not remarried; or"*
+> *   She *"remarried but is widowed, divorced, or legally separated from her husband when she claims preference."*
 
 Which of these specific OPM-defined situations best describes your current status?
 
@@ -32,5 +32,5 @@ Which of these specific OPM-defined situations best describes your current statu
 *   [I am currently married, and my current husband is NOT totally and permanently disabled.](./ineligible_derived_mother_currentmarital.md)
 *   [None of these situations accurately describe my current marital or living status, or I need more clarification.](./derived_mother_clarify_currentmarital.md)
 
-[Return to previous question (Relationship to Veteran's Father)](./derived_mother_common_fatherinfo.md)
-[Return to Advisor Start](./start.md)
+[**Return to previous question (Relationship to Veteran's Father)**](./derived_mother_common_fatherinfo.md)
+[**Return to Advisor Start**](./start.md)

--- a/advisor/derived_mother_common_fatherinfo.md
+++ b/advisor/derived_mother_common_fatherinfo.md
@@ -12,24 +12,23 @@ The OPM Vet Guide for HR Professionals specifies the full criteria for a mother 
 ### Mother of a deceased veteran
 
 For the mother of a veteran who died under honorable conditions on active duty during a war or specific, qualifying military campaigns, she must meet the following conditions:
-*   is or was married to the father of the veteran; **and**
-*   she lives with her totally and permanently disabled husband (either the veteran's father or her husband through remarriage); **or**
-*   she is widowed, divorced, or separated from the veteran's father and has not remarried; **or**
-*   she remarried but is widowed, divorced, or legally separated from her husband when she claims preference.
+> *   is or was married to the father of the veteran; **and**
+> *   she lives with her totally and permanently disabled husband (either the veteran's father or her husband through remarriage); **or**
+> *   she is widowed, divorced, or separated from the veteran's father and has not remarried; **or**
+> *   she remarried but is widowed, divorced, or legally separated from her husband when she claims preference.
 
 ### Mother of a disabled veteran
 
 For the mother of a living veteran who is permanently and totally disabled from a service-connected injury or illness, she must meet the following conditions:
-*   is or was married to the father of the veteran; **and**
-*   lives with her totally and permanently disabled husband (either the veteran's father or her husband through remarriage); **or**
-*   is widowed, divorced, or separated from the veteran's father and has not remarried; **or**
-*   remarried but is widowed, divorced, or legally separated from her husband when she claims preference.
+> *   is or was married to the father of the veteran; **and**
+> *   lives with her totally and permanently disabled husband (either the veteran's father or her husband through remarriage); **or**
+> *   is widowed, divorced, or separated from the veteran's father and has not remarried; **or**
+> *   remarried but is widowed, divorced, or legally separated from her husband when she claims preference.
 
 The first of these conditions is that you are or were married to the father of the veteran. Is this true in your case?
 
 *   [Yes, I am or was married to the father of the veteran.](./derived_mother_common_currentmarital.md)
 *   [No, I am not nor was I ever married to the father of the veteran.](./ineligible_derived_mother_notmarriedtofather.md)
-*   [Go back to the previous question about the veteran's service/status](./derived_mother_vetstatus.md)
-*   [Return to Advisor Start](./advisor/start.md)
+*   [**Go back to the previous question about the veteran's service/status**](./derived_mother_vetstatus.md)
 
-[Return to Advisor Start](./start.md)
+[**Return to Advisor Start**](./start.md)

--- a/advisor/derived_mother_deceased_vetdeathcond.md
+++ b/advisor/derived_mother_deceased_vetdeathcond.md
@@ -11,20 +11,20 @@ To be eligible for derived preference as the mother of a deceased veteran, you m
 
 According to the OPM Vet Guide for HR Professionals, the first part of the eligibility criteria for the "Mother of a deceased veteran" is as follows:
 
-*"Ten points are added to the passing examination score or rating of the mother of a veteran who died under honorable conditions while on active duty during a war or during the period April 28, 1952, through July 1, 1955, or in a campaign or expedition for which a campaign medal has been authorized;"*
+> "Ten points are added to the passing examination score or rating of the mother of a veteran who died under honorable conditions while on active duty during a war or during the period April 28, 1952, through July 1, 1955, or in a campaign or expedition for which a campaign medal has been authorized;"
 
 A **Note** in the Vet Guide further clarifies a significant limitation:
 
-*"Preference is not given to widows or mothers of deceased veterans who qualify for preference under 5 U.S.C. 2108 (1) (B), (C) or (2). Thus, the widow or mother of a deceased disabled veteran who served after 1955, but did not serve in a war, campaign, or expedition, would not be entitled to preference."*
+> "Preference is not given to widows or mothers of deceased veterans who qualify for preference under 5 U.S.C. 2108 (1) (B), (C) or (2). Thus, the widow or mother of a deceased disabled veteran who served after 1955, but did not serve in a war, campaign, or expedition, would not be entitled to preference."
 
 ### Conditions for the Mother
 
 In addition to the veteran's service conditions, the OPM Vet Guide states the mother must also meet specific criteria related to her marital status. The guide specifies that she:
 
-*"is or was married to the father of the veteran; and*
-* *she lives with her totally and permanently disabled husband (either the veteran's father or her husband through remarriage); or*
-* *she is widowed, divorced, or separated from the veteran's father and has not remarried; or*
-* *she remarried but is widowed, divorced, or legally separated from her husband when she claims preference."*
+> "is or was married to the father of the veteran; and
+> * she lives with her totally and permanently disabled husband (either the veteran's father or her husband through remarriage); or
+> * she is widowed, divorced, or separated from the veteran's father and has not remarried; or
+> * she remarried but is widowed, divorced, or legally separated from her husband when she claims preference."
 
 ### Do You Meet These Conditions?
 
@@ -40,5 +40,5 @@ First, did your deceased veteran child die **under honorable conditions** while 
 
 *   [Yes, all these conditions regarding both the veteran's service and my own status apply.](./derived_mother_common_fatherinfo.md)
 *   [No, one or more of these conditions do not apply. (For example, the veteran died on active duty under honorable conditions, but their service after 1955 was not in a war, campaign, or expedition for which a medal was authorized.)](./ineligible_derived_mother_deceased_vetdeathcond.md)
-*   [Return to previous question (Veteran's Status)](./derived_mother_vetstatus.md)
-*   [Return to Advisor Start](./start.md)
+*   [**Return to previous question (Veteran's Status)**](./derived_mother_vetstatus.md)
+*   [**Return to Advisor Start**](./start.md)

--- a/advisor/derived_mother_living_vetseparation.md
+++ b/advisor/derived_mother_living_vetseparation.md
@@ -10,7 +10,7 @@ You previously indicated that your veteran child is living and "is permanently a
 For you to be eligible for derived preference as the mother of a living disabled veteran, your child's service record must meet specific legal requirements. These conditions relate to the nature of their discharge and the type of service they performed.
 
 The OPM's Vet Guide for HR Professionals, under the section "Mother of a disabled veteran," clarifies these requirements. It states that derived preference can be granted if:
-*"...the veteran was separated with an honorable or general discharge from active duty, including training service in the Reserves or National Guard, performed at any time and is permanently and totally disabled from a service-connected injury or illness..."*
+> "...the veteran was separated with an honorable or general discharge from active duty, including training service in the Reserves or National Guard, performed at any time and is permanently and totally disabled from a service-connected injury or illness..."
 
 Therefore, in addition to being permanently and totally disabled, please confirm the following about your veteran child:
 
@@ -25,6 +25,6 @@ If these conditions regarding the veteran's service are met, you will next be as
 
 *   [Yes, these conditions regarding the veteran's separation and nature of service apply.](./derived_mother_common_fatherinfo.md)
 *   [No, one or more of these conditions do not apply (e.g., discharge was not honorable or general).](./ineligible_derived_mother_living_vetseparation.md)
-*   [Return to previous question (Veteran's Status)](./derived_mother_vetstatus.md)
+*   [**Return to previous question (Veteran's Status)**](./derived_mother_vetstatus.md)
 
-[Return to Advisor Start](./start.md)
+[**Return to Advisor Start**](./start.md)

--- a/advisor/derived_preference_step1.md
+++ b/advisor/derived_preference_step1.md
@@ -7,11 +7,11 @@ title: "Veteran's Preference Advisor - Derived Preference - Veteran's Status"
 
 You are exploring **derived preference**. The OPM Vet Guide for HR Professionals explains this under "10-Point Derived Preference (XP)".
 
-*"Ten points are added to the passing examination score or rating of spouses, widows, widowers, or mothers of veterans as described below. This type of preference is usually referred to as "derived preference" because it is based on service of a veteran who is not able to use the preference."*
+> "Ten points are added to the passing examination score or rating of spouses, widows, widowers, or mothers of veterans as described below. This type of preference is usually referred to as "derived preference" because it is based on service of a veteran who is not able to use the preference."
 
 The Vet Guide also provides important context:
 
-*"Both a mother and a spouse (including widow or widower) may be entitled to preference on the basis of the same veteran's service if they both meet the requirements. However, neither may receive preference if the veteran is living and is qualified for Federal employment."*
+> "Both a mother and a spouse (including widow or widower) may be entitled to preference on the basis of the same veteran's service if they both meet the requirements. However, neither may receive preference if the veteran is living and is qualified for Federal employment."
 
 To determine your potential eligibility, we first need to know the status of the **veteran** on whose service this claim would be based.
 
@@ -27,6 +27,6 @@ Is the veteran currently living?
     *   *Note: Derived preference for a widow/widower or mother of a deceased veteran has specific qualifying conditions related to the veteran's service and, for a mother, the circumstances of the veteran's death.*
 
 If you are unsure which path to take based on your relationship, you can return to the relationship selection:
-*   [Return to Relationship Choice](./derived_intro.md)
+*   [**Return to Relationship Choice**](./derived_intro.md)
 
-[Return to Advisor Start](./start.md)
+[**Return to Advisor Start**](./start.md)

--- a/advisor/derived_spouse_furtherclarification.md
+++ b/advisor/derived_spouse_furtherclarification.md
@@ -8,13 +8,13 @@ title: "Derived Preference (Spouse): Further Clarification Recommended"
 You've indicated that the veteran is disqualified for a Federal position along the general lines of his or her usual occupation because of a service-connected disability, but that the situation does not exactly match one of the scenarios where disqualification is typically *presumed*.
 
 The OPM Vet Guide for HR Professionals, under "Spouse," lists these presumed scenarios:
-*"Such a disqualification may be presumed when the veteran is unemployed and"*
-*   *"is rated by appropriate military or Department of Veterans Affairs authorities to be 100 percent disabled and/or unemployable; or"*
-*   *"has retired, been separated, or resigned from a civil service position on the basis of a disability that is service-connected in origin; or"*
-*   *"has attempted to obtain a civil service position or other position along the lines of his or her usual occupation and has failed to qualify because of a service-connected disability."*
+> "Such a disqualification may be presumed when the veteran is unemployed and"
+> *   "is rated by appropriate military or Department of Veterans Affairs authorities to be 100 percent disabled and/or unemployable; or"
+> *   "has retired, been separated, or resigned from a civil service position on the basis of a disability that is service-connected in origin; or"
+> *   "has attempted to obtain a civil service position or other position along the lines of his or her usual occupation and has failed to qualify because of a service-connected disability."
 
 If the veteran's situation does not meet one of these specific conditions (for example, if the veteran is not unemployed, or the circumstances of their inability to find work are different), the OPM Vet Guide advises:
-*"Preference may be allowed in other circumstances but anything less than the above warrants a more careful analysis."*
+> "Preference may be allowed in other circumstances but anything less than the above warrants a more careful analysis."
 
 This means that while you may still be eligible for derived preference, your situation requires a more detailed review by the hiring agency. You will likely need to provide comprehensive documentation with your SF-15 (Application for 10-Point Veteran Preference) to support your claim that the veteran is disqualified for their usual occupation due to their service-connected disability.
 
@@ -34,5 +34,5 @@ To support your claim, you will need to submit the SF-15, Application for 10-Poi
 This advisor cannot make a definitive determination in these more nuanced cases. It is up to the hiring agency to make the final decision based on the documentation provided.
 
 *   ["Understood, I will need to provide detailed documentation. Proceed to information on potential conditional eligibility."](./eligible_xp_derived_spouse_conditional.md)
-*   ["I want to review the presumed disability detail choices again"](./derived_spouse_vetdisabilitydetails.md)
-*   ["Return to Advisor Start"](./start.md)
+*   [**I want to review the presumed disability detail choices again**](./derived_spouse_vetdisabilitydetails.md)
+*   [**Return to Advisor Start**](./start.md)

--- a/advisor/derived_spouse_vetdisabilitydetails.md
+++ b/advisor/derived_spouse_vetdisabilitydetails.md
@@ -9,15 +9,17 @@ Under the rules for 10-Point Derived Preference (XP), ten points can be added to
 
 You've indicated the veteran is disqualified for a Federal position along the general lines of his or her usual occupation because of a service-connected disability.
 
-The OPM Vet Guide for HR Professionals, under "Spouse," states that *"Such a disqualification may be presumed when the veteran is unemployed and"* one of the following conditions is met.
+The OPM Vet Guide for HR Professionals, under "Spouse," states that:
+> *"Such a disqualification may be presumed when the veteran is unemployed and"*
+one of the following conditions is met.
 
 Please select the condition that best describes the veteran's situation (assuming the veteran is currently unemployed):
 
-*   [The veteran is unemployed AND *'is rated by appropriate military or Department of Veterans Affairs authorities to be 100 percent disabled and/or unemployable'*](./advisor/eligible_xp_derived_spouse.md)
-*   [The veteran is unemployed AND *'has retired, been separated, or resigned from a civil service position on the basis of a disability that is service-connected in origin'*](./advisor/eligible_xp_derived_spouse.md)
-*   [The veteran is unemployed AND *'has attempted to obtain a civil service position or other position along the lines of his or her usual occupation and has failed to qualify because of a service-connected disability'*](./advisor/eligible_xp_derived_spouse.md)
-*   [The veteran is disqualified for their usual occupation due to a service-connected disability, and may or may not be unemployed, but none of the specific presumed disqualification scenarios above fully apply, or I'm unsure.](./advisor/derived_spouse_furtherclarification.md) (This may require further clarification as per OPM guidelines.)
+*   [The veteran is unemployed AND 'is rated by appropriate military or Department of Veterans Affairs authorities to be 100 percent disabled and/or unemployable'](./eligible_xp_derived_spouse.md)
+*   [The veteran is unemployed AND 'has retired, been separated, or resigned from a civil service position on the basis of a disability that is service-connected in origin'](./eligible_xp_derived_spouse.md)
+*   [The veteran is unemployed AND 'has attempted to obtain a civil service position or other position along the lines of his or her usual occupation and has failed to qualify because of a service-connected disability'](./eligible_xp_derived_spouse.md)
+*   [The veteran is disqualified for their usual occupation due to a service-connected disability, and may or may not be unemployed, but none of the specific presumed disqualification scenarios above fully apply, or I'm unsure.](./derived_spouse_furtherclarification.md) (This may require further clarification as per OPM guidelines.)
 
-[Return to previous question (Reason for Non-Qualification)](./derived_spouse_vetdisabilityreason.md)
+[**Return to previous question (Reason for Non-Qualification)**](./derived_spouse_vetdisabilityreason.md)
 
-[Return to Advisor Start](./start.md)
+[**Return to Advisor Start**](./start.md)


### PR DESCRIPTION
I applied consistent formatting to a set of advisor markdown files to match the style of "advisor/derived_mother_vetstatus.md".

Changes include:
- Standardized the use of blockquotes ('>') for text extracted from OPM guidance, replacing italicized quotes.
- Ensured all internal page links are relative and their text is not italicized.
- Standardized "return" links at the end of each page:
    - Ensured a `[**Return to Advisor Start**](./start.md)` link is present and bolded.
    - Ensured other contextual "back" or "previous page" links are also bolded.

Files updated:
- advisor/derived_spouse_vetdisabilitydetails.md
- advisor/derived_spouse_furtherclarification.md
- advisor/derived_preference_step1.md
- advisor/derived_mother_living_vetseparation.md
- advisor/derived_mother_deceased_vetdeathcond.md
- advisor/derived_mother_common_fatherinfo.md
- advisor/derived_mother_common_currentmarital.md
- advisor/derived_mother_clarify_currentmarital.md