### PR TITLE
Standardize formatting for advisor pages

### DIFF
--- a/advisor/derived_spouse_vetdisabilityreason.md
+++ b/advisor/derived_spouse_vetdisabilityreason.md
@@ -7,13 +7,23 @@ title: Derived Preference (Spouse): Reason for Veteran's Non-Qualification
 
 You've indicated the veteran is living but is NOT qualified for Federal employment. The reason for this is critical for determining spousal derived preference.
 
-The OPM Vet Guide for HR Professionals, under "Spouse," specifies the condition for eligibility:
-*"Ten points are added to the passing examination score or rating of the spouse of a disabled veteran who is **disqualified for a Federal position along the general lines of his or her usual occupation because of a service-connected disability**."* (emphasis added)
+The Office of Personnel Management (OPM) Vet Guide for HR Professionals, under "Spouse," specifies the condition for eligibility:
+
+> *"Ten points are added to the passing examination score or rating of the spouse of a disabled veteran who is **disqualified for a Federal position along the general lines of his or her usual occupation because of a service-connected disability**."*
+
+### Determining Eligibility Based on Disqualification Reason
 
 Is the veteran disqualified for a Federal position along the general lines of his or her usual occupation **specifically because of a service-connected disability**?
 
-*   `"Yes, the veteran is disqualified for their usual occupation due to a service-connected disability."` -> `advisor/derived_spouse_vetdisabilitydetails.md`
-*   `"No, the veteran is not qualified for Federal employment for reasons other than a service-connected disability that disqualifies them from their usual occupation."` -> `advisor/ineligible_derived_spouse_vetnotdisabled.md`
+---
 
-[Return to previous question](./derived_spouse_vetqualifiedforemployment.md)
-[Return to Advisor Start](./start.md)
+**Please select the option that best describes the reason for the veteran's non-qualification:**
+
+*   [**Yes, the veteran is disqualified for their usual occupation due to a service-connected disability.**](./derived_spouse_vetdisabilitydetails.md)
+    <br>*(Select this if the veteran's service-connected disability is the direct reason they cannot perform their usual job.)*
+
+*   [**No, the veteran is not qualified for Federal employment for reasons other than a service-connected disability that disqualifies them from their usual occupation.**](./ineligible_derived_spouse_vetnotdisabled.md)
+    <br>*(Select this if the veteran's inability to qualify for Federal employment is due to other reasons, not a service-connected disability preventing them from their usual work.)*
+
+*   [**Return to previous question**](./derived_spouse_vetqualifiedforemployment.md)
+*   [**Return to Advisor Start**](./start.md)

--- a/advisor/derived_spouse_vetliving.md
+++ b/advisor/derived_spouse_vetliving.md
@@ -5,13 +5,29 @@ title: Derived Preference (Spouse): Veteran's Status
 
 # Derived Preference (Spouse): Veteran's Status
 
-As the spouse of a veteran, you may be eligible for 10-point derived veteran's preference (XP). The Office of Personnel Management (OPM) Vet Guide for HR Professionals, under "10-Point Derived Preference (XP)," states:
-*"Ten points are added to the passing examination score or rating of spouses, widows, widowers, or mothers of veterans as described below. This type of preference is usually referred to as "derived preference" because it is based on service of a veteran who is not able to use the preference."*
+As the spouse of a veteran, you may be eligible for 10-point derived veteran's preference (XP). This benefit is designed to honor the service of veterans who are unable to use their earned preference themselves.
 
-Is the veteran (on whose service you are basing your claim) currently living?
+### Understanding Derived Preference
 
-*   `"Yes, the veteran is living."` -> `advisor/derived_spouse_vetqualifiedforemployment.md`
-*   `"No, the veteran is deceased."` (This will typically lead to questions for a *widow/widower* rather than a *spouse* of a disabled veteran.) -> `advisor/derived_switch_todeceasedpath.md`
+The Office of Personnel Management (OPM) Vet Guide for HR Professionals, under "10-Point Derived Preference (XP)," states:
 
-[Return to Relationship Choice](./derived_intro.md)
-[Return to Advisor Start](./start.md)
+> *"Ten points are added to the passing examination score or rating of spouses, widows, widowers, or mothers of veterans as described below. This type of preference is usually referred to as "derived preference" because it is based on service of a veteran who is not able to use the preference."*
+
+The core idea is that if the veteran cannot use their preference, it may pass to a qualified spouse, widow/widower, or mother.
+
+### Veteran's Current Status
+
+**Is the veteran (on whose service you are basing your claim) currently living?**
+
+---
+
+**Please select the option that best describes the veteran's status:**
+
+*   [**Yes, the veteran is living.**](./derived_spouse_vetqualifiedforemployment.md)
+    <br>*(Select this if the veteran is alive. Further questions will determine their ability to use their own preference.)*
+
+*   [**No, the veteran is deceased.**](./derived_switch_todeceasedpath.md)
+    <br>*(Select this if the veteran has passed away. This will typically lead to questions for a widow/widower rather than a spouse of a living disabled veteran.)*
+
+*   [**Return to Relationship Choice**](./derived_intro.md)
+*   [**Return to Advisor Start**](./start.md)

--- a/advisor/derived_spouse_vetqualifiedforemployment.md
+++ b/advisor/derived_spouse_vetqualifiedforemployment.md
@@ -5,18 +5,37 @@ title: Derived Preference (Spouse): Veteran's Employment Qualification
 
 # Derived Preference (Spouse): Veteran's Employment Qualification
 
-You've indicated the veteran is currently living. The next crucial factor is whether the veteran is qualified for Federal employment.
+You've indicated the veteran is currently living. The next crucial factor is whether the veteran is qualified for Federal employment, as this directly impacts potential eligibility for derived preference.
 
-The OPM Vet Guide for HR Professionals, under "10-Point Derived Preference (XP)," states a general rule:
-*"However, neither [a mother nor a spouse (including widow or widower)] may receive preference if the veteran is living and is qualified for Federal employment."*
+### Core Principle: Veteran's Ability to Use Preference
 
-Furthermore, for a spouse to be eligible for derived preference, the OPM Vet Guide, under "Spouse," specifies that the veteran must be:
-*"disqualified for a Federal position along the general lines of his or her usual occupation because of a service-connected disability."*
+The Office of Personnel Management (OPM) Vet Guide for HR Professionals, under "10-Point Derived Preference (XP)," states a general rule regarding a living veteran's ability to use their own preference:
 
-Considering these rules, is the living veteran qualified for Federal employment (i.e., generally able to work and apply for Federal jobs)?
+> *"However, neither [a mother nor a spouse (including widow or widower)] may receive preference if the veteran is living and is qualified for Federal employment."*
 
-*   `"Yes, the veteran is living and is considered qualified for Federal employment."` -> `advisor/ineligible_derived_spouse_vetqualified.md`
-*   `"No, the veteran is living but is NOT qualified for Federal employment (potentially due to a service-connected disability that disqualifies them from their usual occupation)."` -> `advisor/derived_spouse_vetdisabilityreason.md`
+This means if the veteran is alive and can use their own preference, derived preference is generally not available to a spouse.
 
-[Return to previous question](./derived_spouse_vetliving.md)
-[Return to Advisor Start](./start.md)
+### Condition for Spousal Derived Preference
+
+Furthermore, for a spouse to be eligible for derived preference when the veteran is living, the OPM Vet Guide, under "Spouse," specifies that the veteran must be:
+
+> *"disqualified for a Federal position along the general lines of his or her usual occupation because of a service-connected disability."*
+
+This highlights that the *reason* for the veteran not being qualified is key.
+
+### Determining Veteran's Qualification for Employment
+
+**Considering these rules, is the living veteran qualified for Federal employment (i.e., generally able to work and apply for Federal jobs)?**
+
+---
+
+**Please select the option that best describes the veteran's employment qualification:**
+
+*   [**Yes, the veteran is living and is considered qualified for Federal employment.**](./ineligible_derived_spouse_vetqualified.md)
+    <br>*(Select this if the veteran is able to work and could apply for Federal jobs, meaning they can use their own preference.)*
+
+*   [**No, the veteran is living but is NOT qualified for Federal employment.**](./derived_spouse_vetdisabilityreason.md)
+    <br>*(Select this if the veteran is unable to work or apply for Federal jobs, potentially due to a service-connected disability that disqualifies them from their usual occupation.)*
+
+*   [**Return to previous question**](./derived_spouse_vetliving.md)
+*   [**Return to Advisor Start**](./start.md)

--- a/advisor/derived_switch_todeceasedpath.md
+++ b/advisor/derived_switch_todeceasedpath.md
@@ -5,20 +5,40 @@ title: Derived Preference: Clarification for Spouse of a Deceased Veteran
 
 # Derived Preference: Clarification for Spouse of a Deceased Veteran
 
-You are exploring **derived preference**. The OPM Vet Guide for HR Professionals, under "10-Point Derived Preference (XP)," explains the general concept:
-*"Ten points are added to the passing examination score or rating of spouses, widows, widowers, or mothers of veterans as described below. This type of preference is usually referred to as "derived preference" because it is based on service of a veteran who is not able to use the preference."*
+You are exploring **derived preference**. The Office of Personnel Management (OPM) Vet Guide for HR Professionals, under "10-Point Derived Preference (XP)," explains the general concept:
 
-You initially indicated you are the **spouse** of a veteran, but then stated that the veteran is **deceased**.
+> *"Ten points are added to the passing examination score or rating of spouses, widows, widowers, or mothers of veterans as described below. This type of preference is usually referred to as "derived preference" because it is based on service of a veteran who is not able to use the preference."*
+
+### Understanding Your Situation
+
+You initially indicated you are the **spouse** of a veteran, but then stated that the veteran is **deceased**. This requires a clarification of terms for veteran's preference purposes.
+
+### Clarification of Terms
+
 In the context of veteran's preference:
+
 *   If you were married to the veteran at the time of their death and meet other conditions (like not remarrying), you would typically apply as a **Widow or Widower**.
-*   The term "Spouse" in derived preference rules usually refers to the spouse of a *living* veteran who is unable to use their preference.
+*   The term "**Spouse**" in derived preference rules usually refers to the spouse of a *living* veteran who is unable to use their preference due to a service-connected disability.
 
-How would you like to proceed based on this clarification?
+### How to Proceed
 
-*   `"Yes, I was married to the veteran at the time of death. Proceed to questions for a Widow/Widower."` -> `derived_widow_divorced.md`
-*   `"I might be eligible as the Mother of the deceased veteran."` -> `derived_mother_vetstatus.md` (You would then select "Deceased" on that page.)
-*   `"The veteran is actually living (I made an error in a previous step)."` -> `derived_spouse_vetqualifiedforemployment.md`
-*   `"[I want to re-evaluate my relationship to the veteran]"` -> `derived_intro.md`
-*   `"[Return to Advisor Start]"` -> `start.md`
+**How would you like to proceed based on this clarification?**
 
-[Return to Advisor Start](./start.md)
+---
+
+**Please select the option that best describes your situation:**
+
+*   [**Yes, I was married to the veteran at the time of death. Proceed to questions for a Widow/Widower.**](./derived_widow_divorced.md)
+    <br>*(Select this if you meet the conditions to apply as a widow or widower.)*
+
+*   [**I might be eligible as the Mother of the deceased veteran.**](./derived_mother_vetstatus.md)
+    <br>*(Select this if you are the mother of the deceased veteran. You would then select "Deceased" on the next page.)*
+
+*   [**The veteran is actually living (I made an error in a previous step).**](./derived_spouse_vetqualifiedforemployment.md)
+    <br>*(Select this to correct your previous input about the veteran's status.)*
+
+*   [**I want to re-evaluate my relationship to the veteran.**](./derived_intro.md)
+    <br>*(Return to the initial relationship selection page.)*
+
+*   [**Return to Advisor Start**](./start.md)
+    <br>*(Go back to the main start page of the advisor.)*


### PR DESCRIPTION
I applied consistent formatting to several advisor markdown files to match the style of "advisor/derived_mother_vetstatus.md".

This includes:
- Consistent use of YAML front matter (layout, title).
- H1 for main titles.
- Blockquotes for OPM guidance.
- H3 for subheadings.
- Consistent bolding for emphasis.
- Use of "---" to separate content from navigation links.
- Standardized markdown link format `[Text](./path.md)`.
- Descriptive text below navigation options using `<br>`.
- Consistent "Return to Advisor Start" links.
- Contextually appropriate "Return to previous step" or "Re-evaluate relationship" links.

Affected files:
- advisor/derived_spouse_vetdisabilityreason.md
- advisor/derived_spouse_vetliving.md
- advisor/derived_spouse_vetqualifiedforemployment.md
- advisor/derived_switch_todeceasedpath.md