### PR TITLE
Refactor: Apply consistent formatting to advisor pages

### DIFF
--- a/advisor/derived_widow_clarify_vetservice.md
+++ b/advisor/derived_widow_clarify_vetservice.md
@@ -5,24 +5,36 @@ title: Derived Preference (Widow/Widower) - Clarification on Veteran's Service
 
 # Derived Preference (Widow/Widower) - Clarification on Veteran's Service
 
-You've indicated you need to clarify the veteran's service conditions. To be eligible for derived preference as a widow/widower, the OPM Vet Guide for HR Professionals, under "Widow/Widower," requires that the veteran's service met specific criteria.
+You've indicated you need to clarify the veteran's service conditions. To be eligible for derived preference as a widow/widower, it's crucial that the deceased veteran's service met specific criteria outlined in the OPM Vet Guide for HR Professionals.
 
-Please review the veteran's service records (such as the DD Form 214) to determine if the veteran:
-1.  *"served during a war or during the period April 28, 1952, through July 1, 1955, or in a campaign or expedition for which a campaign medal has been authorized; or"*
-    *   "War" typically means a war declared by Congress (e.g., World War II, defined by OPM as December 7, 1941, to April 28, 1952).
-    *   The period April 28, 1952, to July 1, 1955, is a specific qualifying timeframe.
-    *   For campaigns or expeditions, consult Appendix A of the OPM Vet Guide for a list of qualifying medals.
-2.  *"died while on active duty that included service described immediately above under conditions that would not have been the basis for other than an honorable or general discharge."*
-    *   This means the veteran died *during* active duty, and that active duty itself was part of service during a war, the specified 1952-1955 period, or a qualifying campaign/expedition.
-    *   The conditions of death must have been honorable.
+### OPM Vet Guide Criteria for Veteran's Service
 
-It's also important to consider the **Note** from the OPM Vet Guide:
-*"Preference is not given to widows or mothers of deceased veterans who qualify for preference under 5 U.S.C. 2108 (1) (B), (C) or (2). Thus, the widow or mother of a deceased disabled veteran who served after 1955, but did not serve in a war, campaign, or expedition, would not be entitled to preference."*
-This means if the veteran's service was entirely after July 1, 1955, and was not in a declared war or a campaign/expedition for which a medal was authorized, you would likely not be eligible for this preference as a widow/widower.
+The OPM Vet Guide, under the section for "Widow/Widower," states that for the widow/widower to be eligible, the veteran must have:
 
-After reviewing the veteran's records against these OPM criteria:
+> *"served during a war or during the period April 28, 1952, through July 1, 1955, or in a campaign or expedition for which a campaign medal has been authorized; or"*
 
-* `"[Return to veteran's service condition choices to make a selection]"` -> `advisor/derived_widow_vetservice_condition.md`
-* `"[Return to Advisor Start]"` -> `advisor/start.md`
+And, if the veteran died while on active duty, that service must have been under honorable conditions:
 
-[Return to Advisor Start](./start.md)
+> *"died while on active duty that included service described immediately above under conditions that would not have been the basis for other than an honorable or general discharge."*
+
+**Key points to verify from the veteran's service records (e.g., DD Form 214):**
+
+*   **Service during a war:** "War" generally refers to a war declared by Congress (e.g., World War II, which OPM defines as December 7, 1941, to April 28, 1952).
+*   **Service during specific period:** The period April 28, 1952, through July 1, 1955, is a qualifying timeframe.
+*   **Service in a campaign/expedition:** For a list of qualifying campaigns and expeditions (and their authorized medals), consult Appendix A of the OPM Vet Guide.
+*   **Death during qualifying active duty:** If the veteran died on active duty, that active duty must have been part of service during a war, the specified 1952-1955 period, or a qualifying campaign/expedition, and the circumstances of death must have been honorable.
+
+### Important Note on Post-1955 Service
+
+It's also critical to consider the following **Note** from the OPM Vet Guide:
+
+> *"Preference is not given to widows or mothers of deceased veterans who qualify for preference under 5 U.S.C. 2108 (1) (B), (C) or (2). Thus, the widow or mother of a deceased disabled veteran who served after 1955, but did not serve in a war, campaign, or expedition, would not be entitled to preference."*
+
+This means if the veteran's service was entirely after July 1, 1955, and was not in a declared war or a campaign/expedition for which a medal was authorized, you, as the widow/widower, would likely not be eligible for this preference.
+
+---
+
+After reviewing the veteran's records against these OPM criteria, please select an option below:
+
+*   [Return to veteran's service condition choices](./derived_widow_vetservice_condition.md)
+*   [Return to Advisor Start](./start.md)

--- a/advisor/derived_widow_divorced.md
+++ b/advisor/derived_widow_divorced.md
@@ -5,16 +5,23 @@ title: Derived Preference (Widow/Widower): Marital Status at Veteran's Death
 
 # Derived Preference (Widow/Widower): Marital Status at Veteran's Death
 
-As a widow or widower of a veteran, you may be eligible for 10-point derived veteran's preference (XP). One of the initial criteria concerns your marital status with the veteran at the time of their death.
+As a widow or widower of a veteran, you may be eligible for 10-point derived veteran's preference (XP). One of the initial criteria the Office of Personnel Management (OPM) considers is your marital status with the veteran at the time of their death.
 
-The OPM Vet Guide for HR Professionals, under "Widow/Widower," states that to be eligible, the widow or widower of a veteran:
-*"...was not divorced from the veteran..."*
+### OPM Rule on Marital Status at Time of Veteran's Death
 
-Were you divorced from the veteran at the time of their death?
+The OPM Vet Guide for HR Professionals, in the section defining "Widow/Widower" for preference eligibility, specifies that the individual:
 
-*   `"Yes, I was divorced from the veteran at the time of their death."` -> `ineligible_derived_widow_divorced.md`
-*   `"No, I was not divorced from the veteran at the time of their death."` -> `derived_widow_remarried.md`
-*   `"[Return to Relationship Choice (e.g., if you are not a widow/widower)]"` -> `derived_intro.md`
-*   `"[Return to Advisor Start]"` -> `start.md`
+> *"...was not divorced from the veteran..."*
 
-[Return to Advisor Start](./start.md)
+This is a critical requirement. If you were legally divorced from the veteran when they passed away, you generally do not meet this specific condition for derived preference as a widow/widower.
+
+---
+
+**Were you divorced from the veteran at the time of their death?**
+
+*   [Yes, I was divorced from the veteran at the time of their death.](./ineligible_derived_widow_divorced.md)
+*   [No, I was not divorced from the veteran at the time of their death.](./derived_widow_remarried.md)
+
+*   [Return to Relationship Choice](./derived_intro.md)
+    <br>*(Select this if you are not a widow/widower or need to change your relationship selection.)*
+*   [Return to Advisor Start](./start.md)

--- a/advisor/derived_widow_remarried.md
+++ b/advisor/derived_widow_remarried.md
@@ -5,14 +5,22 @@ title: Derived Preference (Widow/Widower): Remarriage Status
 
 # Derived Preference (Widow/Widower): Remarriage Status
 
-You've indicated you were not divorced from the veteran at the time of their death. The next condition for derived preference as a widow/widower relates to your remarriage status.
+You've indicated you were not divorced from the veteran at the time of their death. The next condition for derived preference as a widow/widower, as defined by the Office of Personnel Management (OPM), relates to your remarriage status.
 
-The OPM Vet Guide for HR Professionals, under "Widow/Widower," states that to be eligible, the widow or widower:
-*"...has not remarried, or the remarriage was annulled..."*
+### OPM Rule on Remarriage
 
-Have you remarried since the veteran's death?
+The OPM Vet Guide for HR Professionals, in the section defining "Widow/Widower" for preference eligibility, specifies that the individual:
 
-*   `"Yes, I have remarried, and that marriage was NOT annulled."` -> `ineligible_derived_widow_remarried.md`
-*   `"No, I have not remarried SINCE the veteran's death, OR I remarried but that subsequent marriage was annulled."` -> `derived_widow_vetservice_condition.md`
-*   `"[Return to previous question (Divorce Status)]"` -> `derived_widow_divorced.md`
-*   `"[Return to Advisor Start]"` -> `start.md`
+> *"...has not remarried, or the remarriage was annulled..."*
+
+This means that if you have remarried after the veteran's death, that subsequent marriage must have been annulled for you to retain eligibility under this specific condition. If you have not remarried, you meet this condition.
+
+---
+
+**Have you remarried since the veteran's death?**
+
+*   [Yes, I have remarried, and that marriage was NOT annulled.](./ineligible_derived_widow_remarried.md)
+*   [No, I have not remarried SINCE the veteran's death, OR I remarried but that subsequent marriage was annulled.](./derived_widow_vetservice_condition.md)
+
+*   [Return to previous question (Divorce Status)](./derived_widow_divorced.md)
+*   [Return to Advisor Start](./start.md)

--- a/advisor/derived_widow_vetservice_condition.md
+++ b/advisor/derived_widow_vetservice_condition.md
@@ -5,20 +5,40 @@ title: Derived Preference (Widow/Widower): Veteran's Service or Death Conditions
 
 # Derived Preference (Widow/Widower): Veteran's Service or Death Conditions
 
-You've indicated you meet the marital status requirements for a widow/widower. The next set of conditions concerns the veteran's service.
+You've indicated you meet the marital status requirements (not divorced at time of veteran's death and not remarried, or remarriage was annulled). The next crucial set of conditions for derived preference as a widow/widower pertains to the veteran's service history, as outlined by the Office of Personnel Management (OPM).
 
-The OPM Vet Guide for HR Professionals, under "Widow/Widower," specifies that for eligibility, "...the veteran either:
-*   *'served during a war or during the period April 28, 1952, through July 1, 1955, or in a campaign or expedition for which a campaign medal has been authorized; or'*
-*   *'died while on active duty that included service described immediately above under conditions that would not have been the basis for other than an honorable or general discharge.'*"
+### OPM Criteria for Veteran's Service/Death in Service
 
-A **Note** in the Vet Guide further clarifies:
-*"Preference is not given to widows or mothers of deceased veterans who qualify for preference under 5 U.S.C. 2108 (1) (B), (C) or (2). Thus, the widow or mother of a deceased disabled veteran who served after 1955, but did not serve in a war, campaign, or expedition, would not be entitled to preference."*
+The OPM Vet Guide for HR Professionals, under the "Widow/Widower" section, states that for eligibility, the veteran must meet one of the following conditions:
 
-Which of these conditions best describes the veteran's service?
+> *"...served during a war or during the period April 28, 1952, through July 1, 1955, or in a campaign or expedition for which a campaign medal has been authorized; or"*
+>
+> *"...died while on active duty that included service described immediately above under conditions that would not have been the basis for other than an honorable or general discharge."*
 
-*   `"The veteran's service met one of these criteria: served during a war (e.g., World War II: Dec 7, 1941 - Apr 28, 1952); OR served during the period April 28, 1952, through July 1, 1955; OR served in a campaign or expedition for which a campaign medal has been authorized."` (This refers to OPM Vet Guide, section for Widow/Widower, first bullet point) -> `eligible_xp_derived_widow.md`
-*   `"The veteran died while on active duty, AND that active duty included service during a war, or during the period April 28, 1952, through July 1, 1955, or in a campaign or expedition for which a campaign medal has been authorized, AND the death was under conditions that would not have been the basis for other than an honorable or general discharge."` (This refers to OPM Vet Guide, section for Widow/Widower, second bullet point) -> `eligible_xp_derived_widow.md`
-*   `"The veteran's service was after July 1, 1955, AND was NOT in a war, campaign, or expedition for which a campaign medal was authorized (and the veteran did not die on active duty during such specific qualifying service as described above)."` (This likely makes you ineligible based on the OPM Note.) -> `ineligible_derived_widow_vetservicenotqualifying.md`
-*   `"None of these conditions seem to apply, or I'm unsure and need to check the veteran's records."` -> `derived_widow_clarify_vetservice.md`
-*   `"[Return to previous question (Remarriage Status)]"` -> `derived_widow_remarried.md`
-*   `"[Return to Advisor Start]"` -> `start.md`
+### Important Clarification (OPM Note)
+
+The Vet Guide includes an important **Note** that further clarifies eligibility:
+
+> *"Preference is not given to widows or mothers of deceased veterans who qualify for preference under 5 U.S.C. 2108 (1) (B), (C) or (2). Thus, the widow or mother of a deceased disabled veteran who served after 1955, but did not serve in a war, campaign, or expedition, would not be entitled to preference."*
+
+This means if the veteran's service was entirely after July 1, 1955, and was not in a declared war or a qualifying campaign/expedition, derived preference is generally not granted based on that service alone.
+
+---
+
+**Which of these conditions best describes the veteran's service?**
+<br>*(Please review the veteran's DD Form 214 or other official service records carefully.)*
+
+*   [The veteran's service met one of these criteria: served during a war (e.g., World War II: Dec 7, 1941 - Apr 28, 1952); OR served during the period April 28, 1952, through July 1, 1955; OR served in a campaign or expedition for which a campaign medal has been authorized.](./eligible_xp_derived_widow.md)
+    <br>*(This option refers to the first OPM criterion listed above.)*
+
+*   [The veteran died while on active duty, AND that active duty included service during a war, or during the period April 28, 1952, through July 1, 1955, or in a campaign or expedition for which a campaign medal has been authorized, AND the death was under conditions that would not have been the basis for other than an honorable or general discharge.](./eligible_xp_derived_widow.md)
+    <br>*(This option refers to the second OPM criterion listed above.)*
+
+*   [The veteran's service was entirely after July 1, 1955, AND was NOT in a war, campaign, or expedition for which a campaign medal was authorized (and the veteran did not die on active duty during such specific qualifying service as described above).](./ineligible_derived_widow_vetservicenotqualifying.md)
+    <br>*(This option likely makes you ineligible based on the OPM Note.)*
+
+*   [None of these conditions seem to apply, or I'm unsure and need to check the veteran's records.](./derived_widow_clarify_vetservice.md)
+    <br>*(This will take you to a page with more detailed guidance on clarifying service.)*
+
+*   [Return to previous question (Remarriage Status)](./derived_widow_remarried.md)
+*   [Return to Advisor Start](./start.md)


### PR DESCRIPTION
I've standardized the formatting of several advisor markdown files to match the style of `advisor/derived_mother_vetstatus.md`.

This includes:
- Consistent use of blockquotes for OPM Vet Guide excerpts.
- Standardized markdown links for internal navigation.
- Consistent "Return to Advisor Start" and other "Return to..." links.
- Improved page structure with headings where appropriate.
- Added horizontal rules for visual separation.

Affected files:
- advisor/derived_widow_clarify_vetservice.md
- advisor/derived_widow_divorced.md
- advisor/derived_widow_remarried.md
- advisor/derived_widow_vetservice_condition.md