### PR TITLE
Fix: Standardize formatting on advisor pages

### DIFF
--- a/advisor/eligible_xp_derived_mother.md
+++ b/advisor/eligible_xp_derived_mother.md
@@ -5,38 +5,30 @@ title: Veteran's Preference Advisor - Potential 10-Point Derived Preference (XP)
 
 # Veteran's Preference Advisor - Potential 10-Point Derived Preference (XP) - Mother
 
-Based on your responses through this advisor, you appear to meet the conditions for 10-point derived veteran's preference (XP) as the mother of a veteran.
+Based on your responses through this advisor, you appear to meet the conditions for 10-point derived veteran's preference (XP) as the mother of a veteran. The OPM Vet Guide for HR Professionals states: *"Ten points are added to the passing examination score or rating of ... mothers of veterans as described below."*
 
-The Office of Personnel Management (OPM) Vet Guide for HR Professionals states:
-> *"Ten points are added to the passing examination score or rating of ... mothers of veterans as described below."*
-
-### Summary of Conditions Met
+**Summary of Conditions Met:**
 You have indicated that:
-
-*   The veteran (your son or daughter) is either:
+1.  The veteran (your son or daughter) is either:
     *   Deceased, having died under honorable conditions while on active duty during a war, or during the period April 28, 1952, through July 1, 1955, or in a campaign or expedition for which a campaign medal was authorized; OR
     *   Living and permanently and totally disabled from a service-connected injury or illness, having been separated with an honorable or general discharge from active duty (including qualifying training service).
-*   You are or were married to the father of the veteran.
-*   Your current marital/living status meets one of the OPM criteria (e.g., living with a totally and permanently disabled husband; or widowed, divorced, or separated from the veteran's father and not remarried; or remarried but now widowed, divorced, or legally separated from that husband).
-*   The veteran, if living, is not qualified for Federal employment.
+2.  You are or were married to the father of the veteran.
+3.  Your current marital/living status meets one of the OPM criteria (e.g., living with a totally and permanently disabled husband; or widowed, divorced, or separated from the veteran's father and not remarried; or remarried but now widowed, divorced, or legally separated from that husband).
+4.  The veteran, if living, is not qualified for Federal employment.
 
 If these conditions are officially verified, you should be entitled to 10-point derived preference. The OPM Vet Guide clearly outlines these paths for eligibility under "Mother of a deceased veteran" and "Mother of a disabled veteran."
 
-### Next Steps
-This is an initial assessment based on your inputs and **not a final determination**. To claim this preference:
+**Next Steps:**
+This is an initial assessment based on your inputs and not a final determination. To claim this preference:
+* Claim preference when applying for Federal jobs.
+* You **must** complete the Standard Form (SF) 15, Application for 10-Point Veteran Preference.
+* Submit the SF-15 and all requested documentation to the agency you are applying to. Necessary documentation will likely include:
+    * Proof of your relationship to the veteran (e.g., veteran's birth certificate).
+    * Proof of your marriage to the veteran's father.
+    * The veteran's DD Form 214 or other proof of service.
+    * If the veteran is deceased, a death certificate and proof of the circumstances of death if applicable.
+    * If the veteran is living and disabled, official documentation of the veteran's permanent and total service-connected disability rating.
+    * Documentation supporting your current marital and living status as declared.
 
-*   Claim preference when applying for Federal jobs.
-*   You **must** complete the Standard Form (SF) 15, Application for 10-Point Veteran Preference.
-*   Submit the SF-15 and all requested documentation to the agency you are applying to. Necessary documentation will likely include:
-    *   Proof of your relationship to the veteran (e.g., veteran's birth certificate).
-    *   Proof of your marriage to the veteran's father.
-    *   The veteran's DD Form 214 or other proof of service.
-    *   If the veteran is deceased, a death certificate and proof of the circumstances of death if applicable.
-    *   If the veteran is living and disabled, official documentation of the veteran's permanent and total service-connected disability rating.
-    *   Documentation supporting your current marital and living status as declared.
-
----
-
-*   [Learn more about the SF-15 (Application for 10-Point Veteran Preference)](./sf15_information.md)
-*   [Return to Relationship Choice](./derived_intro.md)
-*   [Return to Advisor Start](./start.md)
+* [Learn more about the SF-15 (Application for 10-Point Veteran Preference)](./sf15_information.md)
+* [Return to Advisor Start](./start.md)

--- a/advisor/eligible_xp_derived_spouse.md
+++ b/advisor/eligible_xp_derived_spouse.md
@@ -5,38 +5,29 @@ title: Veteran's Preference Advisor - Potential 10-Point Derived Preference (XP)
 
 # Veteran's Preference Advisor - Potential 10-Point Derived Preference (XP) - Spouse
 
-Based on your responses through this advisor, you appear to meet the conditions for 10-point derived veteran's preference (XP) as the spouse of a disabled veteran.
+Based on your responses through this advisor, you appear to meet the conditions for 10-point derived veteran's preference (XP) as the spouse of a disabled veteran. The OPM Vet Guide for HR Professionals states: *"Ten points are added to the passing examination score or rating of the spouse of a disabled veteran who is disqualified for a Federal position along the general lines of his or her usual occupation because of a service-connected disability."*
 
-The Office of Personnel Management (OPM) Vet Guide for HR Professionals states:
-> *"Ten points are added to the passing examination score or rating of the spouse of a disabled veteran who is disqualified for a Federal position along the general lines of his or her usual occupation because of a service-connected disability."*
-
-### Summary of Conditions Met
+**Summary of Conditions Met:**
 You have indicated that:
-
-*   The veteran is living.
-*   The veteran is **not** qualified for Federal employment.
-*   The veteran's disqualification for a Federal position along the general lines of his or her usual occupation is **because of a service-connected disability**.
-*   The veteran is unemployed, AND one of the following "presumed disqualification" conditions applies:
+1.  The veteran is living.
+2.  The veteran is **not** qualified for Federal employment.
+3.  The veteran's disqualification for a Federal position along the general lines of his or her usual occupation is **because of a service-connected disability**.
+4.  The veteran is unemployed, AND one of the following "presumed disqualification" conditions applies:
     *   The veteran *"is rated by appropriate military or Department of Veterans Affairs authorities to be 100 percent disabled and/or unemployable; or"*
     *   The veteran *"has retired, been separated, or resigned from a civil service position on the basis of a disability that is service-connected in origin; or"*
     *   The veteran *"has attempted to obtain a civil service position or other position along the lines of his or her usual occupation and has failed to qualify because of a service-connected disability."*
 
-If these conditions are officially verified, you should be entitled to 10-point derived preference. The OPM Vet Guide states that:
-> *"Such a disqualification may be presumed"* when these conditions are met.
+If these conditions are officially verified, you should be entitled to 10-point derived preference. The OPM Vet Guide states that *"Such a disqualification may be presumed"* when these conditions are met.
 
-### Next Steps
-This is an initial assessment based on your inputs and **not a final determination**. To claim this preference:
+**Next Steps:**
+This is an initial assessment based on your inputs and not a final determination. To claim this preference:
+* Claim preference when applying for Federal jobs.
+* You **must** complete the Standard Form (SF) 15, Application for 10-Point Veteran Preference.
+* Submit the SF-15 and all requested documentation. This will likely include:
+    * Your marriage certificate.
+    * The veteran's DD Form 214 or other proof of service.
+    * Official documentation of the veteran's service-connected disability.
+    * Evidence of the veteran's unemployability and that it meets one of the conditions listed above (e.g., VA rating of 100% disabled/unemployable, documentation of retirement/separation from civil service due to service-connected disability, or evidence of attempts to find work and failure to qualify due to the disability).
 
-*   Claim preference when applying for Federal jobs.
-*   You **must** complete the Standard Form (SF) 15, Application for 10-Point Veteran Preference.
-*   Submit the SF-15 and all requested documentation. This will likely include:
-    *   Your marriage certificate.
-    *   The veteran's DD Form 214 or other proof of service.
-    *   Official documentation of the veteran's service-connected disability.
-    *   Evidence of the veteran's unemployability and that it meets one of the conditions listed above (e.g., VA rating of 100% disabled/unemployable, documentation of retirement/separation from civil service due to service-connected disability, or evidence of attempts to find work and failure to qualify due to the disability).
-
----
-
-*   [Learn more about the SF-15 (Application for 10-Point Veteran Preference)](./sf15_information.md)
-*   [Return to Previous Step](./derived_spouse_vetqualifiedforemployment.md)
-*   [Return to Advisor Start](./start.md)
+* [Learn more about the SF-15 (Application for 10-Point Veteran Preference)](./sf15_information.md)
+* [Return to Advisor Start](./start.md)

--- a/advisor/eligible_xp_derived_spouse_conditional.md
+++ b/advisor/eligible_xp_derived_spouse_conditional.md
@@ -5,40 +5,31 @@ title: Veteran's Preference Advisor - Potential Conditional 10-Point Derived Pre
 
 # Veteran's Preference Advisor - Potential Conditional 10-Point Derived Preference (XP) - Spouse
 
-Based on your responses through this advisor, you *may* be eligible for 10-point derived veteran's preference (XP) as the spouse of a disabled veteran.
+Based on your responses through this advisor, you *may* be eligible for 10-point derived veteran's preference (XP) as the spouse of a disabled veteran. The OPM Vet Guide for HR Professionals states: *"Ten points are added to the passing examination score or rating of the spouse of a disabled veteran who is disqualified for a Federal position along the general lines of his or her usual occupation because of a service-connected disability."*
 
-The Office of Personnel Management (OPM) Vet Guide for HR Professionals states:
-> *"Ten points are added to the passing examination score or rating of the spouse of a disabled veteran who is disqualified for a Federal position along the general lines of his or her usual occupation because of a service-connected disability."*
-
-### Summary of Your Situation
+**Summary of Your Situation:**
 You have indicated that:
+1.  The veteran is living.
+2.  The veteran is **not** qualified for Federal employment.
+3.  The veteran's disqualification for a Federal position along the general lines of his or her usual occupation is **because of a service-connected disability**.
+4.  However, the veteran's situation does **not** precisely match one of the conditions where *"Such a disqualification may be presumed"* (i.e., 100% VA disability/unemployability rating AND unemployed; or retired/resigned from civil service due to service-connected disability AND unemployed; or failed to qualify for usual occupation due to service-connected disability AND unemployed).
 
-*   The veteran is living.
-*   The veteran is **not** qualified for Federal employment.
-*   The veteran's disqualification for a Federal position along the general lines of his or her usual occupation is **because of a service-connected disability**.
-*   However, the veteran's situation does **not** precisely match one of the conditions where *"Such a disqualification may be presumed"* (i.e., 100% VA disability/unemployability rating AND unemployed; or retired/resigned from civil service due to service-connected disability AND unemployed; or failed to qualify for usual occupation due to service-connected disability AND unemployed).
-
-### Guidance from OPM
-For cases like this, the OPM Vet Guide advises:
-> *"Preference may be allowed in other circumstances but anything less than the above warrants a more careful analysis."*
+**Guidance from OPM:**
+For cases like this, the OPM Vet Guide advises: *"Preference may be allowed in other circumstances but anything less than the above warrants a more careful analysis."*
 
 This means your claim for derived preference is not automatically presumed and will require a thorough review by the hiring agency. If your application for preference is approved after this careful analysis, 10 points would be added to your passing score on a civil service examination.
 
-### Next Steps
-This is an initial assessment based on your inputs and **not a final determination**. To claim this preference:
-
-*   Claim preference when applying for Federal jobs.
-*   You **must** complete the Standard Form (SF) 15, Application for 10-Point Veteran Preference.
-*   **Crucially**, be prepared to provide comprehensive and compelling documentation that clearly demonstrates:
-    *   The veteran's service-connected disability.
-    *   How this disability disqualifies the veteran for a Federal position along the general lines of their usual occupation.
-    *   The veteran's current employment status.
-*   Submit the SF-15 and all supporting documentation to the agency.
+**Next Steps:**
+This is an initial assessment based on your inputs and not a final determination. To claim this preference:
+* Claim preference when applying for Federal jobs.
+* You **must** complete the Standard Form (SF) 15, Application for 10-Point Veteran Preference.
+* **Crucially**, be prepared to provide comprehensive and compelling documentation that clearly demonstrates:
+    * The veteran's service-connected disability.
+    * How this disability disqualifies the veteran for a Federal position along the general lines of their usual occupation.
+    * The veteran's current employment status.
+* Submit the SF-15 and all supporting documentation to the agency.
 
 The agency will then conduct the "more careful analysis" mentioned by OPM.
 
----
-
-*   [Learn more about the SF-15 (Application for 10-Point Veteran Preference)](./sf15_information.md)
-*   [Return to Previous Step](./derived_spouse_vetdisabilitydetails.md)
-*   [Return to Advisor Start](./start.md)
+* [Learn more about the SF-15 (Application for 10-Point Veteran Preference)](./sf15_information.md)
+* [Return to Advisor Start](./start.md)

--- a/advisor/eligible_xp_derived_widow.md
+++ b/advisor/eligible_xp_derived_widow.md
@@ -5,35 +5,27 @@ title: Veteran's Preference Advisor - Potential 10-Point Derived Preference (XP)
 
 # Veteran's Preference Advisor - Potential 10-Point Derived Preference (XP) - Widow/Widower
 
-Based on your responses through this advisor, you appear to meet the conditions for 10-point derived veteran's preference (XP) as the widow/widower of a veteran.
+Based on your responses through this advisor, you appear to meet the conditions for 10-point derived veteran's preference (XP) as the widow/widower of a veteran. The OPM Vet Guide for HR Professionals states: *"Ten points are added to the passing examination score or rating of ... widows, widowers ... of veterans as described below."*
 
-The Office of Personnel Management (OPM) Vet Guide for HR Professionals states:
-> *"Ten points are added to the passing examination score or rating of ... widows, widowers ... of veterans as described below."*
-
-### Summary of Conditions Met
+**Summary of Conditions Met:**
 You have indicated that:
-
-*   You were **not divorced** from the veteran at the time of their death.
-*   You have **not remarried** since the veteran's death, or if you did remarry, that remarriage was **annulled**.
-*   The veteran's service meets one of the following OPM criteria:
+1.  You were **not divorced** from the veteran at the time of their death.
+2.  You have **not remarried** since the veteran's death, or if you did remarry, that remarriage was **annulled**.
+3.  The veteran's service meets one of the following OPM criteria:
     *   The veteran *"served during a war or during the period April 28, 1952, through July 1, 1955, or in a campaign or expedition for which a campaign medal has been authorized; or"*
     *   The veteran *"died while on active duty that included service described immediately above under conditions that would not have been the basis for other than an honorable or general discharge."*
 
 If these conditions are officially verified, you should be entitled to 10-point derived preference. The OPM Vet Guide clearly outlines these requirements under the "Widow/Widower" section of "10-Point Derived Preference (XP)."
 
-### Next Steps
-This is an initial assessment based on your inputs and **not a final determination**. To claim this preference:
+**Next Steps:**
+This is an initial assessment based on your inputs and not a final determination. To claim this preference:
+* Claim preference when applying for Federal jobs.
+* You **must** complete the Standard Form (SF) 15, Application for 10-Point Veteran Preference.
+* Submit the SF-15 and all requested documentation. This will likely include:
+    * Your marriage certificate (to the veteran).
+    * The veteran's death certificate.
+    * The veteran's DD Form 214 or other official proof of service demonstrating qualifying service or death during qualifying active duty.
+    * If applicable, documentation of annulment of any subsequent remarriage.
 
-*   Claim preference when applying for Federal jobs.
-*   You **must** complete the Standard Form (SF) 15, Application for 10-Point Veteran Preference.
-*   Submit the SF-15 and all requested documentation. This will likely include:
-    *   Your marriage certificate (to the veteran).
-    *   The veteran's death certificate.
-    *   The veteran's DD Form 214 or other official proof of service demonstrating qualifying service or death during qualifying active duty.
-    *   If applicable, documentation of annulment of any subsequent remarriage.
-
----
-
-*   [Learn more about the SF-15 (Application for 10-Point Veteran Preference)](./sf15_information.md)
-*   [Return to Previous Step](./derived_widow_vetservice_condition.md)
-*   [Return to Advisor Start](./start.md)
+* [Learn more about the SF-15 (Application for 10-Point Veteran Preference)](./sf15_information.md)
+* [Return to Advisor Start](./start.md)

--- a/advisor/ineligible_derived_mother_currentmarital.md
+++ b/advisor/ineligible_derived_mother_currentmarital.md
@@ -8,15 +8,18 @@ title: Mother's Preference - Ineligible Due to Current Marital/Living Status
 Based on your response regarding your current marital and living situation (e.g., you are currently married and your husband is not totally and permanently disabled), you do not appear to meet the specific conditions required for a mother's 10-point derived preference (XP).
 
 The OPM Vet Guide for HR Professionals, for both "Mother of a deceased veteran" and "Mother of a disabled veteran," requires that after meeting the condition of being married to the veteran's father, the mother also meets **one** of the following criteria regarding her current status:
-*   *"she lives with her totally and permanently disabled husband (either the veteran's father or her husband through remarriage); or"*
-*   *"she is widowed, divorced, or separated from the veteran's father and has not remarried; or"*
-*   *"she remarried but is widowed, divorced, or legally separated from her husband when she claims preference."*
+
+> *"she lives with her totally and permanently disabled husband (either the veteran's father or her husband through remarriage); or"*
+
+> *"she is widowed, divorced, or separated from the veteran's father and has not remarried; or"*
+
+> *"she remarried but is widowed, divorced, or legally separated from her husband when she claims preference."*
 
 If you are currently married and your husband is not totally and permanently disabled, you do not meet the first condition. Being currently married also means you do not meet the latter two conditions, which require you to be widowed, divorced, or separated and not remarried, or to have a subsequent remarriage that has ended.
 
 Therefore, under these OPM guidelines, you would not be eligible for derived preference as a mother.
 
 If you believe your situation is more complex or was misinterpreted:
-* `"[I want to re-evaluate my current marital/living status]"` -> `derived_mother_common_currentmarital.md`
-* `"[Return to Relationship Choice]"` -> `derived_intro.md`
-* `"[Return to Advisor Start]"` -> `start.md`
+* [**I want to re-evaluate my current marital/living status**](./derived_mother_common_currentmarital.md)
+* [**Return to Relationship Choice**](./derived_intro.md)
+* [**Return to Advisor Start**](./start.md)

--- a/advisor/ineligible_derived_mother_deceased_vetdeathcond.md
+++ b/advisor/ineligible_derived_mother_deceased_vetdeathcond.md
@@ -8,16 +8,16 @@ title: Mother's Preference - Ineligible - Deceased Veteran's Service/Death Condi
 Based on your responses, the service or death conditions of the deceased veteran do not appear to meet the specific criteria required for a mother to claim 10-point derived preference (XP).
 
 The OPM Vet Guide for HR Professionals, under "Mother of a deceased veteran," states that eligibility requires the veteran to have:
-*"died under honorable conditions while on active duty during a war or during the period April 28, 1952, through July 1, 1955, or in a campaign or expedition for which a campaign medal has been authorized;"*
+
+> *"died under honorable conditions while on active duty during a war or during the period April 28, 1952, through July 1, 1955, or in a campaign or expedition for which a campaign medal has been authorized;"*
 
 Furthermore, the **Note** in the Vet Guide clarifies an important restriction:
-*"Preference is not given to widows or mothers of deceased veterans who qualify for preference under 5 U.S.C. 2108 (1) (B), (C) or (2). Thus, the widow or mother of a deceased disabled veteran who served after 1955, but did not serve in a war, campaign, or expedition, would not be entitled to preference."*
+
+> *"Preference is not given to widows or mothers of deceased veterans who qualify for preference under 5 U.S.C. 2108 (1) (B), (C) or (2). Thus, the widow or mother of a deceased disabled veteran who served after 1955, but did not serve in a war, campaign, or expedition, would not be entitled to preference."*
 
 This means if the veteran's service was entirely after July 1, 1955, and was not in a declared war or a campaign/expedition for which a medal was authorized, or if they did not die on active duty *during such specific qualifying service*, then derived preference for a mother is generally not granted.
 
 If you believe the veteran's service or death circumstances were misinterpreted:
-*   `"[I want to re-evaluate the veteran's service/death conditions]"` -> `derived_mother_deceased_vetdeathcond.md`
-*   `"[Return to Relationship Choice]"` -> `derived_intro.md`
-*   `"[Return to Advisor Start]"` -> `start.md`
-
-[Return to Advisor Start](./start.md)
+* [**I want to re-evaluate the veteran's service/death conditions**](./derived_mother_deceased_vetdeathcond.md)
+* [**Return to Relationship Choice**](./derived_intro.md)
+* [**Return to Advisor Start**](./start.md)

--- a/advisor/ineligible_derived_mother_living_vetseparation.md
+++ b/advisor/ineligible_derived_mother_living_vetseparation.md
@@ -8,13 +8,12 @@ title: Mother's Preference - Ineligible - Living Veteran's Separation Conditions
 Based on your response, the separation conditions of the living, disabled veteran do not appear to meet the specific criteria required for a mother to claim 10-point derived preference (XP).
 
 The OPM Vet Guide for HR Professionals, under "Mother of a disabled veteran," states that for eligibility, the veteran must have:
-*"...was separated with an honorable or general discharge from active duty, including training service in the Reserves or National Guard, performed at any time and is permanently and totally disabled from a service-connected injury or illness..."*
+
+> *"...was separated with an honorable or general discharge from active duty, including training service in the Reserves or National Guard, performed at any time and is permanently and totally disabled from a service-connected injury or illness..."*
 
 If the veteran was not separated from active duty with an **honorable or general discharge**, then derived preference for a mother is not granted, even if the veteran is permanently and totally disabled from a service-connected injury or illness.
 
 If you believe the veteran's separation conditions were misinterpreted:
-*   `"[I want to re-evaluate the veteran's separation conditions]"` -> `derived_mother_living_vetseparation.md`
-*   `"[Return to Relationship Choice]"` -> `derived_intro.md`
-*   `"[Return to Advisor Start]"` -> `start.md`
-
-[Return to Advisor Start](./start.md)
+* [**I want to re-evaluate the veteran's separation conditions**](./derived_mother_living_vetseparation.md)
+* [**Return to Relationship Choice**](./derived_intro.md)
+* [**Return to Advisor Start**](./start.md)

--- a/advisor/ineligible_derived_mother_notmarriedtofather.md
+++ b/advisor/ineligible_derived_mother_notmarriedtofather.md
@@ -8,12 +8,11 @@ title: Mother's Preference - Ineligible Due to Marital Connection with Veteran's
 Based on your response, you have indicated that you are not now, nor were previously, married to the father of the veteran.
 
 The OPM Vet Guide for HR Professionals specifies a key condition for a mother to be eligible for 10-point derived preference (XP). For both the "Mother of a deceased veteran" and "Mother of a disabled veteran," the guidelines state the mother:
-*"is or was married to the father of the veteran; and"*
+
+> *"is or was married to the father of the veteran; and"*
 
 This is a fundamental requirement. If this condition is not met, you are unfortunately not eligible for derived preference as a mother under these provisions.
 
-*   `"[I made a mistake, I want to change my answer regarding marriage to the veteran's father]"` -> `derived_mother_common_fatherinfo.md`
-*   `"[Return to Relationship Choice (e.g., if you are not applying as a mother)]"` -> `derived_intro.md`
-*   `"[Return to Advisor Start]"` -> `start.md`
-
-[Return to Advisor Start](./start.md)
+* [**I made a mistake, I want to change my answer regarding marriage to the veteran's father**](./derived_mother_common_fatherinfo.md)
+* [**Return to Relationship Choice (e.g., if you are not applying as a mother)**](./derived_intro.md)
+* [**Return to Advisor Start**](./start.md)


### PR DESCRIPTION
I standardized the formatting of quotes and links on several advisor pages to match the style of "advisor/derived_mother_vetstatus.md".

Specifically, the following pages were updated:
- advisor/ineligible_derived_mother_currentmarital.md
- advisor/ineligible_derived_mother_deceased_vetdeathcond.md
- advisor/ineligible_derived_mother_living_vetseparation.md
- advisor/ineligible_derived_mother_notmarriedtofather.md

Changes include:
- Consistent use of Markdown blockquotes (`>`).
- Standardized link format to `[**Link Text**](./path/to/file.md)`.
- Ensured relative paths for links.
- Removed duplicate "Return to Advisor Start" links.