### PR TITLE
Refactor: Standardize formatting of advisor pages

### DIFF
--- a/advisor/ineligible_ownservice_noqualifyingperiod.md
+++ b/advisor/ineligible_ownservice_noqualifyingperiod.md
@@ -8,12 +8,12 @@ layout: default
 Based on your responses, your active duty service, as described, does not appear to align with the specific conditions required for 5-point veteran's preference (TP). This path assumes you are not claiming preference based on a service-connected disability (10-point preference) or a sole survivorship discharge (0-point preference).
 
 The OPM Vet Guide for HR Professionals, under "5-Point Preference (TP)," outlines the criteria. Generally, five points are added for a veteran who served:
-*   *"During a war; or"*
-*   *"During the period April 28, 1952 through July 1, 1955; or"*
-*   *"For more than 180 consecutive days, other than for training, any part of which occurred after January 31, 1955, and before October 15, 1976; or"*
-*   *"During the Gulf War from August 2, 1990, through January 2, 1992; or"*
-*   *"For more than 180 consecutive days, other than for training, any part of which occurred during the period beginning September 11, 2001, and ending on August 31, 2010, the last day of Operation Iraqi Freedom; or"*
-*   *"In a campaign or expedition for which a campaign medal has been authorized."*
+> "During a war; or"
+> "During the period April 28, 1952 through July 1, 1955; or"
+> "For more than 180 consecutive days, other than for training, any part of which occurred after January 31, 1955, and before October 15, 1976; or"
+> "During the Gulf War from August 2, 1990, through January 2, 1992; or"
+> "For more than 180 consecutive days, other than for training, any part of which occurred during the period beginning September 11, 2001, and ending on August 31, 2010, the last day of Operation Iraqi Freedom; or"
+> "In a campaign or expedition for which a campaign medal has been authorized."
 
 If your service does not fall into one of these categories, and you do not meet the minimum duration requirements where applicable (see `ineligible_tp_minduration.md`), you may not be eligible for 5-point preference.
 
@@ -22,6 +22,6 @@ Consider the following:
 *   Are you eligible for a campaign medal you did not initially consider? (See OPM Vet Guide Appendix A for a list).
 *   Might you be eligible for 10-point preference based on a service-connected disability, or 0-point preference due to a sole survivorship discharge?
 
-*   `"[I want to re-check for disability preference (10-point) or sole survivorship preference (0-point)]"` -> `ownservice_checkdisability_intro.md`
-*   `"[I want to review the service period/medal choices for 5-point preference again]"` -> `ownservice_nodisability_nossps_checkserviceperiod.md`
-*   `"[Return to Advisor Start]"` -> `start.md`
+*   [I want to re-check for disability preference (10-point) or sole survivorship preference (0-point)](./ownservice_checkdisability_intro.md)
+*   [I want to review the service period/medal choices for 5-point preference again](./ownservice_nodisability_nossps_checkserviceperiod.md)
+*   [Return to Advisor Start](./start.md)

--- a/advisor/ineligible_ownservice_status.md
+++ b/advisor/ineligible_ownservice_status.md
@@ -7,8 +7,15 @@ title: Ineligible Based on Current Service Status
 
 Based on your responses, you do not currently meet the preliminary requirements for veteran's preference based on your own service status.
 
-The U.S. Office of Personnel Management (OPM) Vet Guide states, "To receive preference, a veteran must have been discharged or released from active duty in the Armed Forces under honorable conditions..." (OPM Vet Guide, 'Types of Preference').
-For those still on active duty, the VOW (Veterans Opportunity to Work) to Hire Heroes Act allows consideration if you are "expected to be discharged or released from active duty service in the armed forces under honorable conditions within 120 days after the certification is submitted by the applicant." (OPM Vet Guide, 'A word about the VOW (Veterans Opportunity to Work) Act').
+The U.S. Office of Personnel Management (OPM) Vet Guide states:
+> To receive preference, a veteran must have been discharged or released from active duty in the Armed Forces under honorable conditions...
+
+(OPM Vet Guide, 'Types of Preference').
+
+For those still on active duty, the VOW (Veterans Opportunity to Work) to Hire Heroes Act allows consideration if you are:
+> expected to be discharged or released from active duty service in the armed forces under honorable conditions within 120 days after the certification is submitted by the applicant.
+
+(OPM Vet Guide, 'A word about the VOW (Veterans Opportunity to Work) Act').
 
 If neither of these situations applies to you (e.g., you are not yet within 120 days of an expected honorable discharge, or your service has not yet concluded under honorable conditions), you typically would not yet be eligible for preference.
 

--- a/advisor/ineligible_retiredmajor_notdisabled.md
+++ b/advisor/ineligible_retiredmajor_notdisabled.md
@@ -8,9 +8,9 @@ title: "Own Service: Ineligible - Retired Officer (Major/Lt. Cmdr or Higher) Not
 Based on your responses, you have indicated that you are a military retiree at the rank of Major, Lieutenant Commander, or higher, and you are not claiming preference as a disabled veteran.
 
 The OPM Vet Guide for HR Professionals, in the section "Types of Preference," states:
-*"Military retirees at the rank of major, lieutenant commander, or higher are not eligible for preference in appointment unless they are disabled veterans. (This does not apply to Reservists who will not begin drawing military retired pay until age 60.)"*
+> Military retirees at the rank of major, lieutenant commander, or higher are not eligible for preference in appointment unless they are disabled veterans. (This does not apply to Reservists who will not begin drawing military retired pay until age 60.)
 
 Under this rule, if you are retired at one of these ranks and are not eligible for preference as a disabled veteran, you generally cannot claim veterans' preference for appointment purposes.
 
-*   `"[I made a mistake, I want to re-check my retirement rank or disability status]"` -> `ownservice_discharged_checkretired.md`
-*   `"[Return to Advisor Start]"` -> `start.md`
+*   [I made a mistake, I want to re-check my retirement rank or disability status](./ownservice_discharged_checkretired.md)
+*   [Return to Advisor Start](./start.md)

--- a/advisor/ineligible_ssp_dischargedate.md
+++ b/advisor/ineligible_ssp_dischargedate.md
@@ -8,10 +8,11 @@ title: Sole Survivor Preference - Ineligible: Discharge Date Requirement Not Met
 Based on your response, your date of release or discharge from active duty does not meet the specific requirement for Sole Survivorship Preference (SSP).
 
 The OPM Vet Guide for HR Professionals, in the section "0-point Preference (SSP)," explains the Hubbard Act:
-*"The Hubbard Act amended the eligibility categories for veterans’ preference purposes by adding subparagraph (H) to 5 U.S.C. 2108(3). Subparagraph (H) establishes a new veterans’ preference eligibility category for veterans released or discharged from a period of active duty from the armed forces, **after August 29, 2008**, by reason of a “sole survivorship discharge.”"* (emphasis added)
+> The Hubbard Act amended the eligibility categories for veterans’ preference purposes by adding subparagraph (H) to 5 U.S.C. 2108(3). Subparagraph (H) establishes a new veterans’ preference eligibility category for veterans released or discharged from a period of active duty from the armed forces, **after August 29, 2008**, by reason of a “sole survivorship discharge.”
+(emphasis added)
 
 If your discharge was on or before August 29, 2008, you are not eligible for Sole Survivorship Preference under this provision. You may still be eligible for other types of veteran's preference (e.g., 5-point or 10-point disability preference) based on other aspects of your service.
 
-*   `"[I made a mistake, I want to re-enter my discharge date]"` -> `ownservice_ssp_checkdd214_date.md`
-*   `"[I want to explore other types of veteran's preference]"` -> `ownservice_nodisability_nossps_checkserviceperiod.md`
-*   `"[Return to Advisor Start]"` -> `start.md`
+*   [I made a mistake, I want to re-enter my discharge date](./ownservice_ssp_checkdd214_date.md)
+*   [I want to explore other types of veteran's preference](./ownservice_nodisability_nossps_checkserviceperiod.md)
+*   [Return to Advisor Start](./start.md)


### PR DESCRIPTION
I've applied consistent formatting to several advisor markdown files to align with the style of `advisor/derived_mother_vetstatus.md`.

My changes include:
- Standardized blockquote usage for quotations.
- Ensured all navigational links use standard Markdown syntax (`[Text](./link.md)`).
- Verified the presence and correct formatting of the "Return to Advisor Start" link on each page.

Affected files:
- advisor/ineligible_ownservice_noqualifyingperiod.md
- advisor/ineligible_ownservice_status.md
- advisor/ineligible_retiredmajor_notdisabled.md
- advisor/ineligible_ssp_dischargedate.md