### PR TITLE
Standardize formatting for advisor pages

### DIFF
--- a/advisor/ineligible_vow_retiredmajor_notdisabled.md
+++ b/advisor/ineligible_vow_retiredmajor_notdisabled.md
@@ -8,9 +8,11 @@ title: "Own Service (VOW Act): Ineligible - Expecting Retirement as Officer (Maj
 Based on your responses as an applicant under the VOW (Veterans Opportunity to Work) Act, you have indicated an expectation to retire at the rank of Major, Lieutenant Commander, or higher, and you are not claiming preference as a disabled veteran.
 
 The OPM Vet Guide for HR Professionals, in the section "Types of Preference," states a rule that also applies to those anticipating retirement:
-*"Military retirees at the rank of major, lieutenant commander, or higher are not eligible for preference in appointment unless they are disabled veterans. (This does not apply to Reservists who will not begin drawing military retired pay until age 60.)"*
+> "Military retirees at the rank of major, lieutenant commander, or higher are not eligible for preference in appointment unless they are disabled veterans. (This does not apply to Reservists who will not begin drawing military retired pay until age 60.)"
 
 If you are discharged/released from active duty and retire at one of these ranks without being eligible for preference as a disabled veteran, you generally cannot claim veterans' preference for appointment purposes. This rule is important to consider when using the VOW Act certification for job applications.
 
-*   `"[I made a mistake, I want to re-check my expected retirement rank or disability status (VOW path)]"` -> `ownservice_vow_checkretired.md`
-*   `"[Return to Advisor Start]"` -> `start.md`
+---
+
+*   [**I made a mistake, I want to re-check my expected retirement rank or disability status (VOW path)**](./ownservice_vow_checkretired.md)
+*   [**Return to Advisor Start**](./start.md)

--- a/advisor/ownservice_checkdisability_intro.md
+++ b/advisor/ownservice_checkdisability_intro.md
@@ -8,12 +8,21 @@ title: Veteran's Preference Advisor - Considering 10-Point Disability Preference
 You are now exploring eligibility for 10-point veteran's preference based on your own service, specifically due to a service-connected disability or receipt of a Purple Heart.
 
 The OPM Vet Guide for HR Professionals outlines several categories for 10-point preference for veterans:
-*   **10-Point Compensable Disability Preference (CP):** *"Ten points are added to the passing examination score or rating of: A veteran who served at any time and who has a compensable service-connected disability rating of at least 10 percent but less than 30 percent."*
-*   **10-Point 30 Percent Compensable Disability Preference (CPS):** *"Ten points are added to the passing examination score or rating of a veteran who served at any time and who has a compensable service-connected disability rating of 30 percent or more."*
-*   **10-Point Disability Preference (XP):** *"Ten points are added to the passing examination score or rating of: A veteran who served at any time and has a present service-connected disability or is receiving compensation, disability retirement benefits, or pension from the military or the Department of Veterans Affairs but does not qualify as a CP or CPS; or A veteran who received a Purple Heart."*
+
+**10-Point Compensable Disability Preference (CP):**
+> "Ten points are added to the passing examination score or rating of: A veteran who served at any time and who has a compensable service-connected disability rating of at least 10 percent but less than 30 percent."
+
+**10-Point 30 Percent Compensable Disability Preference (CPS):**
+> "Ten points are added to the passing examination score or rating of a veteran who served at any time and who has a compensable service-connected disability rating of 30 percent or more."
+
+**10-Point Disability Preference (XP):**
+> "Ten points are added to the passing examination score or rating of: A veteran who served at any time and has a present service-connected disability or is receiving compensation, disability retirement benefits, or pension from the military or the Department of Veterans Affairs but does not qualify as a CP or CPS; or A veteran who received a Purple Heart."
 
 Do you have a service-connected disability recognized by the Department of Veterans Affairs (VA) or your branch of service, OR have you received a Purple Heart?
 
-*   ["Yes, I have a service-connected disability OR I received a Purple Heart."](./ownservice_disability_details.md)
-*   ["No, I do not have a service-connected disability and did not receive a Purple Heart."](./ownservice_discharged_checkfirst_solesurvivor.md) (This will then check for Sole Survivorship)
-*   ["[Return to Advisor Start]"](./start.md)
+---
+
+*   [**Yes, I have a service-connected disability OR I received a Purple Heart.**](./ownservice_disability_details.md)
+*   [**No, I do not have a service-connected disability and did not receive a Purple Heart.**](./ownservice_discharged_checkfirst_solesurvivor.md)
+    <br>*(This will then check for Sole Survivorship)*
+*   [**Return to Advisor Start**](./start.md)

--- a/advisor/ownservice_cp_details.md
+++ b/advisor/ownservice_cp_details.md
@@ -7,8 +7,9 @@ title: Own Service: 10-Point Preference (CP) - 10-20% Disability
 
 You indicated a service-connected disability rating of 10% or 20%. This generally qualifies you for 10-point Veteran's Preference (CP), provided your discharge was (or will be, if VOW Act applies) under honorable conditions and all other general eligibility requirements are met. For disabled veterans, active duty includes training service in the Reserves or National Guard. Remember to complete the SF-15 form.
 
-*   [Confirm, proceed to eligibility summary.](./eligible_cp_10point.md)
-*   [I made a mistake, review disability/Purple Heart options.](./ownservice_disability_details.md)
-*   [Return to Advisor Start](./start.md)
+---
 
-[Return to previous question](./ownservice_disability_details.md)
+*   [**Confirm, proceed to eligibility summary.**](./eligible_cp_10point.md)
+*   [**I made a mistake, review disability/Purple Heart options.**](./ownservice_disability_details.md)
+*   [**Return to Advisor Start**](./start.md)
+*   [**Return to previous question**](./ownservice_disability_details.md)

--- a/advisor/ownservice_cps_details.md
+++ b/advisor/ownservice_cps_details.md
@@ -7,6 +7,8 @@ title: Own Service: 10-Point Preference (CPS) - 30%+ Disability
 
 You indicated a service-connected disability rating of 30% or more. This generally qualifies you for 10-point Veteran's Preference (CPS), provided your discharge was (or will be, if VOW Act applies) under honorable conditions and all other general eligibility requirements are met. For disabled veterans, active duty includes training service in the Reserves or National Guard. Remember to complete the SF-15 form.
 
-*   [Confirm, proceed to eligibility summary.](./eligible_cps_10point.md)
-*   [I made a mistake, review disability/Purple Heart options.](./ownservice_disability_details.md)
-*   [Return to Advisor Start](./start.md)
+---
+
+*   [**Confirm, proceed to eligibility summary.**](./eligible_cps_10point.md)
+*   [**I made a mistake, review disability/Purple Heart options.**](./ownservice_disability_details.md)
+*   [**Return to Advisor Start**](./start.md)


### PR DESCRIPTION
I applied consistent formatting to a set of advisor markdown pages to align with the style of "advisor/derived_mother_vetstatus.md".

Changes include:
- Standardized quote presentation to use markdown blockquotes.
- Uniformed link formatting to `* [**Link Text**](./page.md)`.
- Ensured "Return to Advisor" links match this style.
- Added horizontal rules (`---`) before navigation link blocks.

Affected pages:
- advisor/ineligible_vow_retiredmajor_notdisabled.md
- advisor/ownservice_checkdisability_intro.md
- advisor/ownservice_cp_details.md
- advisor/ownservice_cps_details.md