### PR TITLE
Standardize formatting for advisor pages

### DIFF
--- a/advisor/ineligible_ownservice_noqualifyingperiod.md
+++ b/advisor/ineligible_ownservice_noqualifyingperiod.md
@@ -8,12 +8,12 @@ layout: default
 Based on your responses, your active duty service, as described, does not appear to align with the specific conditions required for 5-point veteran's preference (TP). This path assumes you are not claiming preference based on a service-connected disability (10-point preference) or a sole survivorship discharge (0-point preference).
 
 The OPM Vet Guide for HR Professionals, under "5-Point Preference (TP)," outlines the criteria. Generally, five points are added for a veteran who served:
-*   *"During a war; or"*
-*   *"During the period April 28, 1952 through July 1, 1955; or"*
-*   *"For more than 180 consecutive days, other than for training, any part of which occurred after January 31, 1955, and before October 15, 1976; or"*
-*   *"During the Gulf War from August 2, 1990, through January 2, 1992; or"*
-*   *"For more than 180 consecutive days, other than for training, any part of which occurred during the period beginning September 11, 2001, and ending on August 31, 2010, the last day of Operation Iraqi Freedom; or"*
-*   *"In a campaign or expedition for which a campaign medal has been authorized."*
+> "During a war; or"
+> "During the period April 28, 1952 through July 1, 1955; or"
+> "For more than 180 consecutive days, other than for training, any part of which occurred after January 31, 1955, and before October 15, 1976; or"
+> "During the Gulf War from August 2, 1990, through January 2, 1992; or"
+> "For more than 180 consecutive days, other than for training, any part of which occurred during the period beginning September 11, 2001, and ending on August 31, 2010, the last day of Operation Iraqi Freedom; or"
+> "In a campaign or expedition for which a campaign medal has been authorized."
 
 If your service does not fall into one of these categories, and you do not meet the minimum duration requirements where applicable (see `ineligible_tp_minduration.md`), you may not be eligible for 5-point preference.
 
@@ -22,6 +22,6 @@ Consider the following:
 *   Are you eligible for a campaign medal you did not initially consider? (See OPM Vet Guide Appendix A for a list).
 *   Might you be eligible for 10-point preference based on a service-connected disability, or 0-point preference due to a sole survivorship discharge?
 
-*   `"[I want to re-check for disability preference (10-point) or sole survivorship preference (0-point)]"` -> `ownservice_checkdisability_intro.md`
-*   `"[I want to review the service period/medal choices for 5-point preference again]"` -> `ownservice_nodisability_nossps_checkserviceperiod.md`
-*   `"[Return to Advisor Start]"` -> `start.md`
+*   [I want to re-check for disability preference (10-point) or sole survivorship preference (0-point)](./ownservice_checkdisability_intro.md)
+*   [I want to review the service period/medal choices for 5-point preference again](./ownservice_nodisability_nossps_checkserviceperiod.md)
+*   [Return to Advisor Start](./start.md)

--- a/advisor/ineligible_ownservice_status.md
+++ b/advisor/ineligible_ownservice_status.md
@@ -7,8 +7,15 @@ title: Ineligible Based on Current Service Status
 
 Based on your responses, you do not currently meet the preliminary requirements for veteran's preference based on your own service status.
 
-The U.S. Office of Personnel Management (OPM) Vet Guide states, "To receive preference, a veteran must have been discharged or released from active duty in the Armed Forces under honorable conditions..." (OPM Vet Guide, 'Types of Preference').
-For those still on active duty, the VOW (Veterans Opportunity to Work) to Hire Heroes Act allows consideration if you are "expected to be discharged or released from active duty service in the armed forces under honorable conditions within 120 days after the certification is submitted by the applicant." (OPM Vet Guide, 'A word about the VOW (Veterans Opportunity to Work) Act').
+The U.S. Office of Personnel Management (OPM) Vet Guide states:
+> To receive preference, a veteran must have been discharged or released from active duty in the Armed Forces under honorable conditions...
+
+(OPM Vet Guide, 'Types of Preference').
+
+For those still on active duty, the VOW (Veterans Opportunity to Work) to Hire Heroes Act allows consideration if you are:
+> expected to be discharged or released from active duty service in the armed forces under honorable conditions within 120 days after the certification is submitted by the applicant.
+
+(OPM Vet Guide, 'A word about the VOW (Veterans Opportunity to Work) Act').
 
 If neither of these situations applies to you (e.g., you are not yet within 120 days of an expected honorable discharge, or your service has not yet concluded under honorable conditions), you typically would not yet be eligible for preference.
 

--- a/advisor/ineligible_retiredmajor_notdisabled.md
+++ b/advisor/ineligible_retiredmajor_notdisabled.md
@@ -8,9 +8,9 @@ title: "Own Service: Ineligible - Retired Officer (Major/Lt. Cmdr or Higher) Not
 Based on your responses, you have indicated that you are a military retiree at the rank of Major, Lieutenant Commander, or higher, and you are not claiming preference as a disabled veteran.
 
 The OPM Vet Guide for HR Professionals, in the section "Types of Preference," states:
-*"Military retirees at the rank of major, lieutenant commander, or higher are not eligible for preference in appointment unless they are disabled veterans. (This does not apply to Reservists who will not begin drawing military retired pay until age 60.)"*
+> Military retirees at the rank of major, lieutenant commander, or higher are not eligible for preference in appointment unless they are disabled veterans. (This does not apply to Reservists who will not begin drawing military retired pay until age 60.)
 
 Under this rule, if you are retired at one of these ranks and are not eligible for preference as a disabled veteran, you generally cannot claim veterans' preference for appointment purposes.
 
-*   `"[I made a mistake, I want to re-check my retirement rank or disability status]"` -> `ownservice_discharged_checkretired.md`
-*   `"[Return to Advisor Start]"` -> `start.md`
+*   [I made a mistake, I want to re-check my retirement rank or disability status](./ownservice_discharged_checkretired.md)
+*   [Return to Advisor Start](./start.md)

--- a/advisor/ineligible_ssp_dischargedate.md
+++ b/advisor/ineligible_ssp_dischargedate.md
@@ -8,10 +8,11 @@ title: Sole Survivor Preference - Ineligible: Discharge Date Requirement Not Met
 Based on your response, your date of release or discharge from active duty does not meet the specific requirement for Sole Survivorship Preference (SSP).
 
 The OPM Vet Guide for HR Professionals, in the section "0-point Preference (SSP)," explains the Hubbard Act:
-*"The Hubbard Act amended the eligibility categories for veterans’ preference purposes by adding subparagraph (H) to 5 U.S.C. 2108(3). Subparagraph (H) establishes a new veterans’ preference eligibility category for veterans released or discharged from a period of active duty from the armed forces, **after August 29, 2008**, by reason of a “sole survivorship discharge.”"* (emphasis added)
+> The Hubbard Act amended the eligibility categories for veterans’ preference purposes by adding subparagraph (H) to 5 U.S.C. 2108(3). Subparagraph (H) establishes a new veterans’ preference eligibility category for veterans released or discharged from a period of active duty from the armed forces, **after August 29, 2008**, by reason of a “sole survivorship discharge.”
+(emphasis added)
 
 If your discharge was on or before August 29, 2008, you are not eligible for Sole Survivorship Preference under this provision. You may still be eligible for other types of veteran's preference (e.g., 5-point or 10-point disability preference) based on other aspects of your service.
 
-*   `"[I made a mistake, I want to re-enter my discharge date]"` -> `ownservice_ssp_checkdd214_date.md`
-*   `"[I want to explore other types of veteran's preference]"` -> `ownservice_nodisability_nossps_checkserviceperiod.md`
-*   `"[Return to Advisor Start]"` -> `start.md`
+*   [I made a mistake, I want to re-enter my discharge date](./ownservice_ssp_checkdd214_date.md)
+*   [I want to explore other types of veteran's preference](./ownservice_nodisability_nossps_checkserviceperiod.md)
+*   [Return to Advisor Start](./start.md)

--- a/advisor/ineligible_ssp_familycriteria.md
+++ b/advisor/ineligible_ssp_familycriteria.md
@@ -8,15 +8,15 @@ title: Sole Survivor Preference - Ineligible: Family Criteria Not Met
 Based on your response, the family circumstances you described do not align with the specific criteria required for Sole Survivorship Preference (SSP).
 
 The OPM Vet Guide for HR Professionals, in the section "0-point Preference (SSP)," details these family-related conditions. Eligibility is for a veteran who is the only surviving child in a family where:
-> ...the father or mother or one or more siblings:
-> * served in the armed forces, and
-> * was killed, died as a result of wounds, accident, or disease, is in a captured or missing in action status, or is permanently 100 percent disabled or hospitalized on a continuing basis (and is not employed gainfully because of the disability or hospitalization), where
-> * the death, status, or disability did not result from the intentional misconduct or willful neglect of the parent or sibling and was not incurred during a period of unauthorized absence.
+*"...the father or mother or one or more siblings:
+* served in the armed forces, and
+* was killed, died as a result of wounds, accident, or disease, is in a captured or missing in action status, or is permanently 100 percent disabled or hospitalized on a continuing basis (and is not employed gainfully because of the disability or hospitalization), where
+* the death, status, or disability did not result from the intentional misconduct or willful neglect of the parent or sibling and was not incurred during a period of unauthorized absence."*
 
 If these specific conditions regarding a parent or sibling are not met, you are not eligible for Sole Survivorship Preference, even if you received a "sole survivorship discharge" for other reasons or meet the discharge date requirement.
 
 You may still be eligible for other types of veteran's preference (e.g., 5-point or 10-point disability preference) based on other aspects of your service.
 
-*   [**I made a mistake, I want to re-evaluate the family criteria**](./ownservice_ssp_familycriteria_info.md)
-*   [**I want to explore other types of veteran's preference**](./ownservice_nodisability_nossps_checkserviceperiod.md)
-*   [**Return to Advisor Start**](./start.md)
+*   `"[I made a mistake, I want to re-evaluate the family criteria]"` -> `ownservice_ssp_familycriteria_info.md`
+*   `"[I want to explore other types of veteran's preference]"` -> `ownservice_nodisability_nossps_checkserviceperiod.md`
+*   `"[Return to Advisor Start]"` -> `start.md`

--- a/advisor/ineligible_ssp_reason.md
+++ b/advisor/ineligible_ssp_reason.md
@@ -8,12 +8,12 @@ title: "Sole Survivor Preference - Ineligible: Reason for Discharge Not - Sole S
 Based on your response, the reason for your discharge from active duty was not a "sole survivorship discharge."
 
 The OPM Vet Guide for HR Professionals, in the section "0-point Preference (SSP)," explains that eligibility for this preference category is for:
-> ...veterans released or discharged from a period of active duty from the armed forces, after August 29, 2008, **by reason of a “sole survivorship discharge.”** (emphasis added)
+*"...veterans released or discharged from a period of active duty from the armed forces, after August 29, 2008, **by reason of a “sole survivorship discharge.”**"* (emphasis added)
 
 If your discharge was for reasons other than a "sole survivorship discharge," you are not eligible for Sole Survivorship Preference (SSP), even if your discharge occurred after August 29, 2008.
 
 You may still be eligible for other types of veteran's preference (e.g., 5-point or 10-point disability preference) based on other aspects of your service.
 
-*   [**I made a mistake, I want to re-evaluate the reason for my discharge**](./ownservice_ssp_checkdd214_reason.md)
-*   [**I want to explore other types of veteran's preference**](./ownservice_nodisability_nossps_checkserviceperiod.md)
-*   [**Return to Advisor Start**](./start.md)
+*   [I made a mistake, I want to re-evaluate the reason for my discharge](./ownservice_ssp_checkdd214_reason.md)
+*   [I want to explore other types of veteran's preference](./ownservice_nodisability_nossps_checkserviceperiod.md)
+*   [Return to Advisor Start](./start.md)

--- a/advisor/ineligible_tp_minduration.md
+++ b/advisor/ineligible_tp_minduration.md
@@ -8,13 +8,13 @@ layout: default
 Based on your responses, you may not meet the minimum active-duty service requirement for 5-point preference (TP), particularly if your service began after September 7, 1980 (or you began active duty on or after October 14, 1982, without previously completing 24 months of continuous active duty).
 
 The OPM Vet Guide for HR Professionals, in the "5-Point Preference (TP)" section, states:
-> A campaign medal holder or Gulf War veteran who originally enlisted after September 7, 1980, (or began active duty on or after October 14, 1982, and has not previously completed 24 months of continuous active duty) must have served continuously for 24 months or the full period called or ordered to active duty.
+*"A campaign medal holder or Gulf War veteran who originally enlisted after September 7, 1980, (or began active duty on or after October 14, 1982, and has not previously completed 24 months of continuous active duty) must have served continuously for 24 months or the full period called or ordered to active duty."*
 
 It further notes:
-> The 24-month service requirement does not apply to 10-point preference eligibles separated for disability incurred or aggravated in the line of duty, or to veterans separated for hardship or other reasons under 10 U.S.C. 1171 or 1173. (This is also referenced in 38 U.S.C. 5303A(d)).
+*"The 24-month service requirement does not apply to 10-point preference eligibles separated for disability incurred or aggravated in the line of duty, or to veterans separated for hardship or other reasons under 10 U.S.C. 1171 or 1173."* (This is also referenced in 38 U.S.C. 5303A(d)).
 
 If you do not meet this 24-month continuous service requirement (or did not complete the full period for which you were called/ordered to active duty) and the exceptions for disability or specific hardship separations do not apply to you, you may not be eligible for 5-point preference under this rule.
 
-*   [**I want to review my service duration or check if exceptions apply**](./ownservice_tp_24month_duration.md)
-*   [**I want to review other service period choices for 5-point preference**](./ownservice_nodisability_nossps_checkserviceperiod.md)
-*   [**Return to Advisor Start**](./start.md)
+*   `"[I want to review my service duration or check if exceptions apply]"` -> `ownservice_tp_24month_duration.md`
+*   `"[I want to review other service period choices for 5-point preference]"` -> `ownservice_nodisability_nossps_checkserviceperiod.md`
+*   `"[Return to Advisor Start]"` -> `start.md`

--- a/advisor/ineligible_vow_discharge_type.md
+++ b/advisor/ineligible_vow_discharge_type.md
@@ -8,12 +8,12 @@ title: "Own Service (VOW Act): Potentially Ineligible - Discharge Not Certified 
 Based on your response, your VOW (Veterans Opportunity to Work) Act certification does not indicate that your service member is expected to be discharged or released from active duty service under honorable conditions.
 
 The OPM Vet Guide for HR Professionals, in the section "A word about the VOW (Veterans Opportunity to Work) Act," describes the certification requirement:
-> A “certification” is any written document from the armed forces that certifies the service member is expected to be discharged or released from active duty service in the armed forces **under honorable conditions** within 120 days after the certification is submitted by the applicant. (emphasis added)
+*"A “certification” is any written document from the armed forces that certifies the service member is expected to be discharged or released from active duty service in the armed forces **under honorable conditions** within 120 days after the certification is submitted by the applicant."* (emphasis added)
 
 It also notes a general requirement for preference in the "Types of Preference" section:
-> To receive preference, a veteran must have been discharged or released from active duty in the Armed Forces under honorable conditions (i.e., with an honorable or general discharge).
+*"To receive preference, a veteran must have been discharged or released from active duty in the Armed Forces under honorable conditions (i.e., with an honorable or general discharge)."*
 
 If your certification does not affirm an expectation of discharge under honorable conditions, agencies cannot grant tentative preference under the VOW Act. Final preference eligibility also depends on the actual character of service upon discharge.
 
-*   [**I made a mistake, I want to re-check my VOW certification details regarding discharge conditions**](./ownservice_vow_honorableconditions.md)
-*   [**Return to Advisor Start**](./start.md)
+*   `"[I made a mistake, I want to re-check my VOW certification details regarding discharge conditions]"` -> `ownservice_vow_honorableconditions.md`
+*   `"[Return to Advisor Start]"` -> `start.md`

--- a/advisor/ownservice_disability_clarify_sf15.md
+++ b/advisor/ownservice_disability_clarify_sf15.md
@@ -5,7 +5,7 @@ title: Own Service: Disability Preference - Clarification Needed
 
 # Own Service: Disability Preference - Clarification Needed
 
-Understanding your specific disability rating and type is important for determining 10-point preference. Please review your documentation from the Department of Veterans Affairs (VA) or your branch of service. [cite_start]The Standard Form 15 (SF-15), 'Application for 10-Point Veteran Preference,' also provides details on required documentation. Once you have more information, you can select the appropriate option from the previous page.
+Understanding your specific disability rating and type is important for determining 10-point preference. Please review your documentation from the Department of Veterans Affairs (VA) or your branch of service. "The Standard Form 15 (SF-15), 'Application for 10-Point Veteran Preference,' also provides details on required documentation." Once you have more information, you can select the appropriate option from the previous page.
 
 *   [Return to disability/Purple Heart options.](./ownservice_disability_details.md)
 *   [Return to Advisor Start](./start.md)

--- a/advisor/ownservice_disability_details.md
+++ b/advisor/ownservice_disability_details.md
@@ -1,15 +1,15 @@
 ---
 layout: default
-title: "Own Service: Disability or Purple Heart Details"
+title: Own Service: Disability or Purple Heart Details
 ---
 
 # Own Service: Disability or Purple Heart Details
 
 You indicated you have a service-connected disability or received a Purple Heart. To determine the type of 10-point preference, please select the option that best describes your situation. (Remember, if you are claiming 10-point preference, you will typically need to complete an SF-15 form and provide supporting documentation.)
 
-*   ["I received a Purple Heart."](./ownservice_xp_purpleheart.md)
-*   ["I have a service-connected disability rating of 30% or more from the VA or my branch of service."](./ownservice_cps_details.md)
-*   ["I have a service-connected disability rating of 10% or 20% from the VA or my branch of service."](./ownservice_cp_details.md)
-*   ["I have a service-connected disability (rated less than 10% or not yet rated but recognized) OR I am receiving compensation, disability retirement benefits, or pension from the military or VA due to a service-connected disability, but I don't fit the 10-30%+ categories above."](./ownservice_xp_generaldisability_details.md)
-*   ["I'm not sure about the percentage or type."](./ownservice_disability_clarify_sf15.md)
-*   "[Return to Advisor Start](./start.md)"
+*   [I received a Purple Heart.](./ownservice_xp_purpleheart.md)
+*   [I have a service-connected disability rating of 30% or more from the VA or my branch of service.](./ownservice_cps_details.md)
+*   [I have a service-connected disability rating of 10% or 20% from the VA or my branch of service.](./ownservice_cp_details.md)
+*   [I have a service-connected disability (rated less than 10% or not yet rated but recognized) OR I am receiving compensation, disability retirement benefits, or pension from the military or VA due to a service-connected disability, but I don't fit the 10-30%+ categories above.](./ownservice_xp_generaldisability_details.md)
+*   [I'm not sure about the percentage or type.](./ownservice_disability_clarify_sf15.md)
+*   [Return to Advisor Start](./start.md)

--- a/advisor/ownservice_discharged_checkdd214_discharge.md
+++ b/advisor/ownservice_discharged_checkdd214_discharge.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "Own Service: Discharged - Check DD Form 214 for Discharge"
+title: Own Service: Discharged - Check DD Form 214 for Discharge
 ---
 
 # Own Service: Discharged - Check DD Form 214 for Discharge

--- a/advisor/ownservice_discharged_checkfirst_solesurvivor.md
+++ b/advisor/ownservice_discharged_checkfirst_solesurvivor.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "Own Service: Check for Sole Survivorship Preference"
+title: Own Service: Check for Sole Survivorship Preference
 ---
 
 # Own Service: Check for Sole Survivorship Preference
@@ -9,7 +9,7 @@ You've indicated no current claim to disability/Purple Heart preference. Now we 
 
 The Sole Survivorship Preference (SSP) is a specific type of preference. Let's check if this might apply to you.
 
-First, were you released or discharged from active duty **after August 29, 2008**, AND was the discharge specifically by reason of a **'sole survivorship discharge'**? (This is often noted on your DD Form 214. See OPM Vet Guide, '0-point Preference (SSP)').
+First, were you released or discharged from active duty **after August 29, 2008**, AND was the discharge specifically by reason of a **'sole survivorship discharge'**? (This is often noted on your DD Form 214. See "OPM Vet Guide", '0-point Preference (SSP)').
 
 * [Yes, I believe these conditions might apply to me, or I want to check.](./ownservice_ssp_checkdd214_date.md)
 * [No, these conditions do not apply, or I'm not sure.](./ownservice_nodisability_nossps_checkserviceperiod.md)


### PR DESCRIPTION
I updated several advisor markdown pages to ensure consistent use of quotes, link formatting, and 'Return to Advisor' link style, matching the format of advisor/derived_mother_vetstatus.md.

Changes were applied to:
- advisor/ownservice_disability_clarify_sf15.md
- advisor/ownservice_disability_details.md
- advisor/ownservice_discharged_checkdd214_discharge.md
- advisor/ownservice_discharged_checkfirst_solesurvivor.md