### PR TITLE
Refactor: Standardize formatting of advisor pages

### DIFF
--- a/advisor/ineligible_vow_retiredmajor_notdisabled.md
+++ b/advisor/ineligible_vow_retiredmajor_notdisabled.md
@@ -8,9 +8,11 @@ title: "Own Service (VOW Act): Ineligible - Expecting Retirement as Officer (Maj
 Based on your responses as an applicant under the VOW (Veterans Opportunity to Work) Act, you have indicated an expectation to retire at the rank of Major, Lieutenant Commander, or higher, and you are not claiming preference as a disabled veteran.
 
 The OPM Vet Guide for HR Professionals, in the section "Types of Preference," states a rule that also applies to those anticipating retirement:
-*"Military retirees at the rank of major, lieutenant commander, or higher are not eligible for preference in appointment unless they are disabled veterans. (This does not apply to Reservists who will not begin drawing military retired pay until age 60.)"*
+> "Military retirees at the rank of major, lieutenant commander, or higher are not eligible for preference in appointment unless they are disabled veterans. (This does not apply to Reservists who will not begin drawing military retired pay until age 60.)"
 
 If you are discharged/released from active duty and retire at one of these ranks without being eligible for preference as a disabled veteran, you generally cannot claim veterans' preference for appointment purposes. This rule is important to consider when using the VOW Act certification for job applications.
 
-*   `"[I made a mistake, I want to re-check my expected retirement rank or disability status (VOW path)]"` -> `ownservice_vow_checkretired.md`
-*   `"[Return to Advisor Start]"` -> `start.md`
+---
+
+*   [**I made a mistake, I want to re-check my expected retirement rank or disability status (VOW path)**](./ownservice_vow_checkretired.md)
+*   [**Return to Advisor Start**](./start.md)

--- a/advisor/ownservice_checkdisability_intro.md
+++ b/advisor/ownservice_checkdisability_intro.md
@@ -8,12 +8,21 @@ title: Veteran's Preference Advisor - Considering 10-Point Disability Preference
 You are now exploring eligibility for 10-point veteran's preference based on your own service, specifically due to a service-connected disability or receipt of a Purple Heart.
 
 The OPM Vet Guide for HR Professionals outlines several categories for 10-point preference for veterans:
-*   **10-Point Compensable Disability Preference (CP):** *"Ten points are added to the passing examination score or rating of: A veteran who served at any time and who has a compensable service-connected disability rating of at least 10 percent but less than 30 percent."*
-*   **10-Point 30 Percent Compensable Disability Preference (CPS):** *"Ten points are added to the passing examination score or rating of a veteran who served at any time and who has a compensable service-connected disability rating of 30 percent or more."*
-*   **10-Point Disability Preference (XP):** *"Ten points are added to the passing examination score or rating of: A veteran who served at any time and has a present service-connected disability or is receiving compensation, disability retirement benefits, or pension from the military or the Department of Veterans Affairs but does not qualify as a CP or CPS; or A veteran who received a Purple Heart."*
+
+**10-Point Compensable Disability Preference (CP):**
+> "Ten points are added to the passing examination score or rating of: A veteran who served at any time and who has a compensable service-connected disability rating of at least 10 percent but less than 30 percent."
+
+**10-Point 30 Percent Compensable Disability Preference (CPS):**
+> "Ten points are added to the passing examination score or rating of a veteran who served at any time and who has a compensable service-connected disability rating of 30 percent or more."
+
+**10-Point Disability Preference (XP):**
+> "Ten points are added to the passing examination score or rating of: A veteran who served at any time and has a present service-connected disability or is receiving compensation, disability retirement benefits, or pension from the military or the Department of Veterans Affairs but does not qualify as a CP or CPS; or A veteran who received a Purple Heart."
 
 Do you have a service-connected disability recognized by the Department of Veterans Affairs (VA) or your branch of service, OR have you received a Purple Heart?
 
-*   ["Yes, I have a service-connected disability OR I received a Purple Heart."](./ownservice_disability_details.md)
-*   ["No, I do not have a service-connected disability and did not receive a Purple Heart."](./ownservice_discharged_checkfirst_solesurvivor.md) (This will then check for Sole Survivorship)
-*   ["[Return to Advisor Start]"](./start.md)
+---
+
+*   [**Yes, I have a service-connected disability OR I received a Purple Heart.**](./ownservice_disability_details.md)
+*   [**No, I do not have a service-connected disability and did not receive a Purple Heart.**](./ownservice_discharged_checkfirst_solesurvivor.md)
+    <br>*(This will then check for Sole Survivorship)*
+*   [**Return to Advisor Start**](./start.md)

--- a/advisor/ownservice_cp_details.md
+++ b/advisor/ownservice_cp_details.md
@@ -7,8 +7,9 @@ title: Own Service: 10-Point Preference (CP) - 10-20% Disability
 
 You indicated a service-connected disability rating of 10% or 20%. This generally qualifies you for 10-point Veteran's Preference (CP), provided your discharge was (or will be, if VOW Act applies) under honorable conditions and all other general eligibility requirements are met. For disabled veterans, active duty includes training service in the Reserves or National Guard. Remember to complete the SF-15 form.
 
-*   [Confirm, proceed to eligibility summary.](./eligible_cp_10point.md)
-*   [I made a mistake, review disability/Purple Heart options.](./ownservice_disability_details.md)
-*   [Return to Advisor Start](./start.md)
+---
 
-[Return to previous question](./ownservice_disability_details.md)
+*   [**Confirm, proceed to eligibility summary.**](./eligible_cp_10point.md)
+*   [**I made a mistake, review disability/Purple Heart options.**](./ownservice_disability_details.md)
+*   [**Return to Advisor Start**](./start.md)
+*   [**Return to previous question**](./ownservice_disability_details.md)

--- a/advisor/ownservice_cps_details.md
+++ b/advisor/ownservice_cps_details.md
@@ -7,6 +7,8 @@ title: Own Service: 10-Point Preference (CPS) - 30%+ Disability
 
 You indicated a service-connected disability rating of 30% or more. This generally qualifies you for 10-point Veteran's Preference (CPS), provided your discharge was (or will be, if VOW Act applies) under honorable conditions and all other general eligibility requirements are met. For disabled veterans, active duty includes training service in the Reserves or National Guard. Remember to complete the SF-15 form.
 
-*   [Confirm, proceed to eligibility summary.](./eligible_cps_10point.md)
-*   [I made a mistake, review disability/Purple Heart options.](./ownservice_disability_details.md)
-*   [Return to Advisor Start](./start.md)
+---
+
+*   [**Confirm, proceed to eligibility summary.**](./eligible_cps_10point.md)
+*   [**I made a mistake, review disability/Purple Heart options.**](./ownservice_disability_details.md)
+*   [**Return to Advisor Start**](./start.md)

--- a/advisor/ownservice_disability_clarify_sf15.md
+++ b/advisor/ownservice_disability_clarify_sf15.md
@@ -5,7 +5,7 @@ title: Own Service: Disability Preference - Clarification Needed
 
 # Own Service: Disability Preference - Clarification Needed
 
-Understanding your specific disability rating and type is important for determining 10-point preference. Please review your documentation from the Department of Veterans Affairs (VA) or your branch of service. [cite_start]The Standard Form 15 (SF-15), 'Application for 10-Point Veteran Preference,' also provides details on required documentation. Once you have more information, you can select the appropriate option from the previous page.
+Understanding your specific disability rating and type is important for determining 10-point preference. Please review your documentation from the Department of Veterans Affairs (VA) or your branch of service. "The Standard Form 15 (SF-15), 'Application for 10-Point Veteran Preference,' also provides details on required documentation." Once you have more information, you can select the appropriate option from the previous page.
 
 *   [Return to disability/Purple Heart options.](./ownservice_disability_details.md)
 *   [Return to Advisor Start](./start.md)

--- a/advisor/ownservice_disability_details.md
+++ b/advisor/ownservice_disability_details.md
@@ -1,15 +1,15 @@
 ---
 layout: default
-title: "Own Service: Disability or Purple Heart Details"
+title: Own Service: Disability or Purple Heart Details
 ---
 
 # Own Service: Disability or Purple Heart Details
 
 You indicated you have a service-connected disability or received a Purple Heart. To determine the type of 10-point preference, please select the option that best describes your situation. (Remember, if you are claiming 10-point preference, you will typically need to complete an SF-15 form and provide supporting documentation.)
 
-*   ["I received a Purple Heart."](./ownservice_xp_purpleheart.md)
-*   ["I have a service-connected disability rating of 30% or more from the VA or my branch of service."](./ownservice_cps_details.md)
-*   ["I have a service-connected disability rating of 10% or 20% from the VA or my branch of service."](./ownservice_cp_details.md)
-*   ["I have a service-connected disability (rated less than 10% or not yet rated but recognized) OR I am receiving compensation, disability retirement benefits, or pension from the military or VA due to a service-connected disability, but I don't fit the 10-30%+ categories above."](./ownservice_xp_generaldisability_details.md)
-*   ["I'm not sure about the percentage or type."](./ownservice_disability_clarify_sf15.md)
-*   "[Return to Advisor Start](./start.md)"
+*   [I received a Purple Heart.](./ownservice_xp_purpleheart.md)
+*   [I have a service-connected disability rating of 30% or more from the VA or my branch of service.](./ownservice_cps_details.md)
+*   [I have a service-connected disability rating of 10% or 20% from the VA or my branch of service.](./ownservice_cp_details.md)
+*   [I have a service-connected disability (rated less than 10% or not yet rated but recognized) OR I am receiving compensation, disability retirement benefits, or pension from the military or VA due to a service-connected disability, but I don't fit the 10-30%+ categories above.](./ownservice_xp_generaldisability_details.md)
+*   [I'm not sure about the percentage or type.](./ownservice_disability_clarify_sf15.md)
+*   [Return to Advisor Start](./start.md)

--- a/advisor/ownservice_discharged_checkdd214_discharge.md
+++ b/advisor/ownservice_discharged_checkdd214_discharge.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "Own Service: Discharged - Check DD Form 214 for Discharge"
+title: Own Service: Discharged - Check DD Form 214 for Discharge
 ---
 
 # Own Service: Discharged - Check DD Form 214 for Discharge

--- a/advisor/ownservice_discharged_checkfirst_solesurvivor.md
+++ b/advisor/ownservice_discharged_checkfirst_solesurvivor.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "Own Service: Check for Sole Survivorship Preference"
+title: Own Service: Check for Sole Survivorship Preference
 ---
 
 # Own Service: Check for Sole Survivorship Preference
@@ -9,7 +9,7 @@ You've indicated no current claim to disability/Purple Heart preference. Now we 
 
 The Sole Survivorship Preference (SSP) is a specific type of preference. Let's check if this might apply to you.
 
-First, were you released or discharged from active duty **after August 29, 2008**, AND was the discharge specifically by reason of a **'sole survivorship discharge'**? (This is often noted on your DD Form 214. See OPM Vet Guide, '0-point Preference (SSP)').
+First, were you released or discharged from active duty **after August 29, 2008**, AND was the discharge specifically by reason of a **'sole survivorship discharge'**? (This is often noted on your DD Form 214. See "OPM Vet Guide", '0-point Preference (SSP)').
 
 * [Yes, I believe these conditions might apply to me, or I want to check.](./ownservice_ssp_checkdd214_date.md)
 * [No, these conditions do not apply, or I'm not sure.](./ownservice_nodisability_nossps_checkserviceperiod.md)

--- a/advisor/ownservice_discharged_checkretired.md
+++ b/advisor/ownservice_discharged_checkretired.md
@@ -7,7 +7,7 @@ title: "Own Service: Discharged - Check Retiree Status"
 
 Are you a military retiree at the rank of Major, Lieutenant Commander, or higher? (This generally does not apply to Reservists who will not begin drawing military retired pay until age 60. See OPM Vet Guide, 'Types of Preference' and Appendix C for rank equivalents).
 
-*   [**Yes, I am a retiree at Major/Lt. Commander or higher.**](./ownservice_discharged_retiredmajor_isdisabled.md)
-*   [**No, I am not a retiree at that rank, OR I am a Reservist not yet drawing retired pay until age 60.**](./ownservice_discharged_honorableconditions.md)
+*   [Yes, I am a retiree at Major/Lt. Commander or higher.](./ownservice_discharged_retiredmajor_isdisabled.md)
+*   [No, I am not a retiree at that rank, OR I am a Reservist not yet drawing retired pay until age 60.](./ownservice_discharged_honorableconditions.md)
 
-[**Return to Advisor Start**](./start.md)
+[Return to Advisor Start](./start.md)

--- a/advisor/ownservice_discharged_honorableconditions.md
+++ b/advisor/ownservice_discharged_honorableconditions.md
@@ -7,11 +7,8 @@ title: "Own Service: Discharged - Character of Service"
 
 To receive preference, a veteran must have been discharged or released from active duty in the Armed Forces under honorable conditions. This typically means an Honorable or General discharge. (OPM Vet Guide, 'Types of Preference'). What was the character of your discharge?
 
-*   [**Honorable or General Discharge.**](./ownservice_checkdisability_intro.md)
-    <br>*(This is the most common type of discharge for preference eligibility.)*
-*   [**Other than Honorable/General (e.g., Undesirable, Bad Conduct, Dishonorable).**](./ineligible_discharge_type.md)
-    <br>*(These types of discharges typically do not qualify for veteran's preference.)*
-*   [**I'm not sure / Need to check my DD Form 214.**](./ownservice_discharged_checkdd214_discharge.md)
-    <br>*(Your DD Form 214 will list the character of your discharge.)*
+*   [Honorable or General Discharge.](./ownservice_checkdisability_intro.md)
+*   [Other than Honorable/General (e.g., Undesirable, Bad Conduct, Dishonorable).](./ineligible_discharge_type.md)
+*   [I'm not sure / Need to check my DD Form 214.](./ownservice_discharged_checkdd214_discharge.md)
 
-[**Return to Advisor Start**](./start.md)
+[Return to Advisor Start](./start.md)

--- a/advisor/ownservice_discharged_retiredmajor_isdisabled.md
+++ b/advisor/ownservice_discharged_retiredmajor_isdisabled.md
@@ -7,9 +7,7 @@ title: "Own Service: Retired Major/Lt. Cmdr+ - Check Disability"
 
 Military retirees at the rank of Major, Lieutenant Commander, or higher are generally not eligible for preference in appointment unless they are disabled veterans. (OPM Vet Guide, 'Types of Preference'). Do you have a service-connected disability recognized by the Department of Veterans Affairs (VA) or your branch of service?
 
-*   [**Yes, I am a disabled veteran.**](./ownservice_discharged_honorableconditions.md)
-    <br>*(This may allow you to claim preference despite your retired rank.)*
-*   [**No, I am not a disabled veteran.**](./ineligible_retiredmajor_notdisabled.md)
-    <br>*(Retirees at this rank without a service-connected disability are generally not eligible for preference.)*
+*   [Yes, I am a disabled veteran.](./ownservice_discharged_honorableconditions.md)
+*   [No, I am not a disabled veteran.](./ineligible_retiredmajor_notdisabled.md)
 
-[**Return to Advisor Start**](./start.md)
+[Return to Advisor Start](./start.md)

--- a/advisor/ownservice_intro.md
+++ b/advisor/ownservice_intro.md
@@ -11,11 +11,8 @@ For preference purposes, "active duty" typically refers to full-time service in 
 
 To proceed, please select your current status:
 
-*   [**I have been discharged or released from active duty in the Armed Forces.**](./ownservice_discharged_checkretired.md)
-    <br>*(This is the most common status for veterans seeking preference.)*
-*   [**I am currently an active duty service member and expect to be discharged or released from active duty service under honorable conditions within 120 days (and I have or can obtain a certification as described in the VOW Act).**](./ownservice_vow_checkretired.md)
-    <br>*(This applies if you are approaching separation and meet VOW Act requirements.)*
-*   [**None of the above apply to me.**](./ineligible_ownservice_status.md)
-    <br>*(Select this if neither of the other options describes your situation.)*
+*   [I have been discharged or released from active duty in the Armed Forces.](./ownservice_discharged_checkretired.md)
+*   [I am currently an active duty service member and expect to be discharged or released from active duty service under honorable conditions within 120 days (and I have or can obtain a certification as described in the VOW Act).](./ownservice_vow_checkretired.md)
+*   [None of the above apply to me.](./ineligible_ownservice_status.md)
 
-[**Return to Advisor Start**](./start.md)
+[Return to Advisor Start](./start.md)

--- a/advisor/ownservice_nodisability_nossps_checkserviceperiod.md
+++ b/advisor/ownservice_nodisability_nossps_checkserviceperiod.md
@@ -7,12 +7,23 @@ title: "Own Service: Check Service Periods for 5-Point Preference (TP)"
 
 Since you haven't indicated eligibility for disability or sole survivorship preference at this stage, let's check if your service meets criteria for 5-point preference (TP). Did your active service (not solely for training, if you are non-disabled) include any of the following periods or events? (Select all that apply, or the one that best fits. We will address the 24-month service requirement later if applicable. See OPM Vet Guide, '5-Point Preference (TP)' for details on qualifying periods.)
 
-*   [Service during a declared war (specifically World War II: December 7, 1941 - April 28, 1952).](./ownservice_tp_wartime_wwii.md)
-*   [Service during the period April 28, 1952, through July 1, 1955.](./ownservice_tp_period_1952_1955.md)
-*   [Service for more than 180 consecutive days (other than for training), any part of which occurred after January 31, 1955, and before October 15, 1976.](./ownservice_tp_period_1955_1976.md)
-*   [Service during the Gulf War from August 2, 1990, through January 2, 1992.](./ownservice_tp_period_gulfwar1.md)
-*   [Service for more than 180 consecutive days (other than for training), any part of which occurred during the period beginning September 11, 2001, and ending on August 31, 2010 (the last day of Operation Iraqi Freedom).](./ownservice_tp_period_post911_oif.md)
-*   [Service in a campaign or expedition for which a campaign medal has been authorized (e.g., Armed Forces Expeditionary Medal).](./ownservice_tp_campaignmedal.md) (Refer to OPM Vet Guide Appendix A for a list)
-*   [None of the above service periods or medals apply to me.](./ineligible_ownservice_noqualifyingperiod.md)
+*   [**Service during a declared war (specifically World War II: December 7, 1941 - April 28, 1952).**](./ownservice_tp_wartime_wwii.md)
+    <br>*(This period covers active service during World War II)*
+*   [**Service during the period April 28, 1952, through July 1, 1955.**](./ownservice_tp_period_1952_1955.md)
+    <br>*(This period covers certain active service after World War II)*
+*   [**Service for more than 180 consecutive days (other than for training), any part of which occurred after January 31, 1955, and before October 15, 1976.**](./ownservice_tp_period_1955_1976.md)
+    <br>*(This covers extended service periods between the Korean War and Vietnam Era)*
+*   [**Service during the Gulf War from August 2, 1990, through January 2, 1992.**](./ownservice_tp_period_gulfwar1.md)
+    <br>*(This covers service during the initial Gulf War period)*
+*   [**Service for more than 180 consecutive days (other than for training), any part of which occurred during the period beginning September 11, 2001, and ending on August 31, 2010 (the last day of Operation Iraqi Freedom).**](./ownservice_tp_period_post911_oif.md)
+    <br>*(This covers extended service post-9/11 up to the end of Operation Iraqi Freedom)*
+*   [**Service in a campaign or expedition for which a campaign medal has been authorized (e.g., Armed Forces Expeditionary Medal).**](./ownservice_tp_campaignmedal.md) (Refer to OPM Vet Guide Appendix A for a list)
+    <br>*(If you received a campaign medal not covered by other periods)*
+*   [**None of the above service periods or medals apply to me.**](./ineligible_ownservice_noqualifyingperiod.md)
+    <br>*(Select this if your service does not match any of these criteria)*
 
-[Return to Advisor Start](./start.md)
+---
+*   [**Return to previous eligibility questions**](./ownservice_intro.md)
+    <br>*(Go back to the initial questions about your own service)*
+*   [**Return to Advisor Start**](./start.md)
+    <br>*(Go back to the main advisor page)*

--- a/advisor/ownservice_ssp_checkdd214_date.md
+++ b/advisor/ownservice_ssp_checkdd214_date.md
@@ -9,8 +9,12 @@ For Sole Survivorship Preference, your discharge must have occurred **after Augu
 
 Please check your DD Form 214 (Certificate of Release or Discharge from Active Duty) for the date of your discharge or release from the relevant period of active duty.
 
-*   [My discharge was after August 29, 2008.](./ownservice_ssp_checkdd214_reason.md)
-*   [My discharge was on or before August 29, 2008.](./ineligible_ssp_dischargedate.md)
-*   [Return to previous question.](./ownservice_discharged_checkfirst_solesurvivor.md)
-*   [Return to Advisor Start](./start.md)
+*   [**My discharge was after August 29, 2008.**](./ownservice_ssp_checkdd214_reason.md)
+    <br>*(This meets the date requirement; proceed to the next question about discharge reason)*
+*   [**My discharge was on or before August 29, 2008.**](./ineligible_ssp_dischargedate.md)
+    <br>*(This date does not meet the requirement for Sole Survivorship Preference)*
+*   [**Return to previous question.**](./ownservice_discharged_checkfirst_solesurvivor.md)
+    <br>*(Go back to the previous question about Sole Survivorship eligibility)*
+*   [**Return to Advisor Start**](./start.md)
+    <br>*(Go back to the main advisor page)*
 ---

--- a/advisor/ownservice_ssp_checkdd214_reason.md
+++ b/advisor/ownservice_ssp_checkdd214_reason.md
@@ -9,8 +9,12 @@ For Sole Survivorship Preference, your discharge must have been explicitly by re
 
 Please check your DD Form 214 (Certificate of Release or Discharge from Active Duty) or other official separation documents for the stated reason or authority for your discharge.
 
-*   [Yes, the reason documented was "sole survivorship discharge".](./ownservice_ssp_familycriteria_info.md)
-*   [No, the reason documented was different or unclear regarding sole survivorship.](./ineligible_ssp_reason.md)
-*   [I need to check the discharge date again.](./ownservice_ssp_checkdd214_date.md)
-*   [Return to Advisor Start](./start.md)
+*   [**Yes, the reason documented was "sole survivorship discharge".**](./ownservice_ssp_familycriteria_info.md)
+    <br>*(This meets a key requirement for Sole Survivorship Preference; proceed to family criteria)*
+*   [**No, the reason documented was different or unclear regarding sole survivorship.**](./ineligible_ssp_reason.md)
+    <br>*(This may mean you are not eligible for Sole Survivorship Preference based on discharge reason)*
+*   [**I need to check the discharge date again.**](./ownservice_ssp_checkdd214_date.md)
+    <br>*(Return to the previous step to verify your discharge date)*
+*   [**Return to Advisor Start**](./start.md)
+    <br>*(Go back to the main advisor page)*
 ---

--- a/advisor/ownservice_ssp_eligible.md
+++ b/advisor/ownservice_ssp_eligible.md
@@ -7,22 +7,25 @@ title: Eligible for Sole Survivor Preference (SSP)
 
 Based on your responses, you **may be eligible** for Sole Survivorship Preference (SSP).
 
-**What is Sole Survivorship Preference?**
+### What is Sole Survivorship Preference?
 
 Sole Survivorship Preference (SSP) is a 0-point preference. This means that while it does not add points to your score in an examination, it grants preference over non-preference eligibles in hiring decisions for federal positions, provided all other requirements for the position are met.
 
 Specifically, if you are an SSP eligible, an agency may not select a non-preference eligible over you unless the agency files a written objection with OPM and OPM approves the agency's request to pass over you.
 
-**Key Conditions Met:**
+### Key Conditions Met:
 *   You were released or discharged from active duty after August 29, 2008.
 *   Your discharge was by reason of a "sole survivorship discharge."
 *   You meet the family survivorship criteria associated with this type of discharge.
 
-**Next Steps:**
+### Next Steps:
 *   Ensure you have documentation of your "sole survivorship discharge" (typically found on your DD Form 214 or other official military documents).
 *   When applying for federal positions, be sure to claim this preference as instructed in the job announcement.
 
 While this advisor provides guidance, the hiring agency makes the final determination on veteran's preference.
 
-*   [Learn more about different types of Veteran's Preference (OPM Vet Guide)](https://www.opm.gov/policy-data-oversight/veterans-services/vet-guide-for-hr-professionals/) <!-- TODO: SME to verify this link and provide a more specific anchor if possible -->
-*   [Return to Advisor Start](./start.md)
+---
+*   [**Learn more about different types of Veteran's Preference (OPM Vet Guide)**](https://www.opm.gov/policy-data-oversight/veterans-services/vet-guide-for-hr-professionals/) <!-- TODO: SME to verify this link and provide a more specific anchor if possible -->
+    <br>*(Opens the official OPM Vet Guide for HR Professionals in a new tab)*
+*   [**Return to Advisor Start**](./start.md)
+    <br>*(Go back to the main advisor page)*


### PR DESCRIPTION
I've applied consistent formatting to several advisor pages to match the style of `advisor/derived_mother_vetstatus.md`.

Changes include:
- Uniform styling for links: bold text, `<br>` tag, and italicized descriptions.
- Consistent use of H1 and H3 headings.
- Ensured presence of a horizontal rule (`---`) before navigation link sections.
- Added relevant 'Return to previous page' links where appropriate.

Files updated:
- advisor/ownservice_nodisability_nossps_checkserviceperiod.md
- advisor/ownservice_ssp_checkdd214_date.md
- advisor/ownservice_ssp_checkdd214_reason.md
- advisor/ownservice_ssp_eligible.md