### PR TITLE
Update formatting of advisor/derived_intro.md

### DIFF
--- a/advisor/derived_intro.md
+++ b/advisor/derived_intro.md
@@ -8,16 +8,22 @@ title: Derived Veteran's Preference - Relationship to Veteran
 You are exploring eligibility for **derived veteran's preference**. This type of preference allows certain relatives of veterans to receive preference in hiring.
 
 The OPM Vet Guide for HR Professionals, in its section on "10-Point Derived Preference (XP)," explains:
-*"Ten points are added to the passing examination score or rating of spouses, widows, widowers, or mothers of veterans as described below. This type of preference is usually referred to as "derived preference" because it is based on service of a veteran who is not able to use the preference."*
+> *"Ten points are added to the passing examination score or rating of spouses, widows, widowers, or mothers of veterans as described below. This type of preference is usually referred to as "derived preference" because it is based on service of a veteran who is not able to use the preference."*
 This recognizes that the veteran's service can also create eligibility for their closest family members under specific circumstances, especially if the veteran is unable to use the preference themselves.
 
-This is generally a 10-point preference. The OPM (Office of Personnel Management) Vet Guide also notes: *"Applicants claiming 10-point preference must complete Standard Form (SF) 15, Application for 10-Point Veteran Preference, and submit the requested documentation."* (SF-15 is Standard Form 15).
+This is generally a 10-point preference. The OPM (Office of Personnel Management) Vet Guide also notes:
+> *"Applicants claiming 10-point preference must complete Standard Form (SF) 15, Application for 10-Point Veteran Preference, and submit the requested documentation."* (SF-15 is Standard Form 15).
 
 To begin, what is your relationship to the veteran on whose service this claim would be based?
 
-*   [I am the spouse of a veteran](./derived_spouse_vetliving.md)
-*   [I am the widow or widower of a veteran](./derived_widow_divorced.md)
-*   [I am the mother of a veteran.](./derived_mother_vetstatus.md)
-*   [None of the above / I made a mistake (Return to Start)](./start.md)
+*   **[I am the spouse of a veteran](./derived_spouse_vetliving.md)**
+    <br>_Select this if you are the legal spouse of a veteran._
+*   **[I am the widow or widower of a veteran](./derived_widow_divorced.md)**
+    <br>_Select this if you are the widow or widower of a veteran._
+*   **[I am the mother of a veteran.](./derived_mother_vetstatus.md)**
+    <br>_Select this if you are the mother of a veteran._
+*   **[None of the above / I made a mistake (Return to Start)](./start.md)**
+    <br>_Select this if none of the other options apply or to return to the beginning._
 
-[Return to Advisor Start](./start.md)
+---
+*   [**Return to Advisor Start**](./start.md)


### PR DESCRIPTION
I've applied formatting changes to advisor/derived_intro.md to align with the style of advisor/derived_mother_vetstatus.md.

Key changes include:
- Ensured OPM quotes are formatted as blockquotes.
- Standardized link styling for navigation choices (bold link, italicized description on new line).
- Ensured "Return to Advisor Start" link matches the simpler style of similar links in the reference file (bold link, no description).
- Added a horizontal rule for separation before final navigation links.