### PR TITLE
Standardize formatting for advisor pages

### DIFF
--- a/advisor/derived_intro.md
+++ b/advisor/derived_intro.md
@@ -8,16 +8,22 @@ title: Derived Veteran's Preference - Relationship to Veteran
 You are exploring eligibility for **derived veteran's preference**. This type of preference allows certain relatives of veterans to receive preference in hiring.
 
 The OPM Vet Guide for HR Professionals, in its section on "10-Point Derived Preference (XP)," explains:
-*"Ten points are added to the passing examination score or rating of spouses, widows, widowers, or mothers of veterans as described below. This type of preference is usually referred to as "derived preference" because it is based on service of a veteran who is not able to use the preference."*
+> *"Ten points are added to the passing examination score or rating of spouses, widows, widowers, or mothers of veterans as described below. This type of preference is usually referred to as "derived preference" because it is based on service of a veteran who is not able to use the preference."*
 This recognizes that the veteran's service can also create eligibility for their closest family members under specific circumstances, especially if the veteran is unable to use the preference themselves.
 
-This is generally a 10-point preference. The OPM (Office of Personnel Management) Vet Guide also notes: *"Applicants claiming 10-point preference must complete Standard Form (SF) 15, Application for 10-Point Veteran Preference, and submit the requested documentation."* (SF-15 is Standard Form 15).
+This is generally a 10-point preference. The OPM (Office of Personnel Management) Vet Guide also notes:
+> *"Applicants claiming 10-point preference must complete Standard Form (SF) 15, Application for 10-Point Veteran Preference, and submit the requested documentation."* (SF-15 is Standard Form 15).
 
 To begin, what is your relationship to the veteran on whose service this claim would be based?
 
-*   [I am the spouse of a veteran](./derived_spouse_vetliving.md)
-*   [I am the widow or widower of a veteran](./derived_widow_divorced.md)
-*   [I am the mother of a veteran.](./derived_mother_vetstatus.md)
-*   [None of the above / I made a mistake (Return to Start)](./start.md)
+*   **[I am the spouse of a veteran](./derived_spouse_vetliving.md)**
+    <br>_Select this if you are the legal spouse of a veteran._
+*   **[I am the widow or widower of a veteran](./derived_widow_divorced.md)**
+    <br>_Select this if you are the widow or widower of a veteran._
+*   **[I am the mother of a veteran.](./derived_mother_vetstatus.md)**
+    <br>_Select this if you are the mother of a veteran._
+*   **[None of the above / I made a mistake (Return to Start)](./start.md)**
+    <br>_Select this if none of the other options apply or to return to the beginning._
 
-[Return to Advisor Start](./start.md)
+---
+*   [**Return to Advisor Start**](./start.md)

--- a/advisor/derived_spouse_vetdisabilityreason.md
+++ b/advisor/derived_spouse_vetdisabilityreason.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Derived Preference (Spouse): Reason for Veteran's Non-Qualification
+title: "Derived Preference (Spouse): Reason for Veteran's Non-Qualification"
 ---
 
 # Derived Preference (Spouse): Reason for Veteran's Non-Qualification

--- a/advisor/derived_spouse_vetliving.md
+++ b/advisor/derived_spouse_vetliving.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Derived Preference (Spouse): Veteran's Status
+title: "Derived Preference (Spouse): Veteran's Status"
 ---
 
 # Derived Preference (Spouse): Veteran's Status

--- a/advisor/derived_spouse_vetqualifiedforemployment.md
+++ b/advisor/derived_spouse_vetqualifiedforemployment.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Derived Preference (Spouse): Veteran's Employment Qualification
+title: "Derived Preference (Spouse): Veteran's Employment Qualification"
 ---
 
 # Derived Preference (Spouse): Veteran's Employment Qualification

--- a/advisor/derived_switch_todeceasedpath.md
+++ b/advisor/derived_switch_todeceasedpath.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Derived Preference: Clarification for Spouse of a Deceased Veteran
+title: "Derived Preference: Clarification for Spouse of a Deceased Veteran"
 ---
 
 # Derived Preference: Clarification for Spouse of a Deceased Veteran

--- a/advisor/derived_widow_divorced.md
+++ b/advisor/derived_widow_divorced.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Derived Preference (Widow/Widower): Marital Status at Veteran's Death
+title: "Derived Preference (Widow/Widower): Marital Status at Veteran's Death"
 ---
 
 # Derived Preference (Widow/Widower): Marital Status at Veteran's Death

--- a/advisor/derived_widow_remarried.md
+++ b/advisor/derived_widow_remarried.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Derived Preference (Widow/Widower): Remarriage Status
+title: "Derived Preference (Widow/Widower): Remarriage Status"
 ---
 
 # Derived Preference (Widow/Widower): Remarriage Status

--- a/advisor/derived_widow_vetservice_condition.md
+++ b/advisor/derived_widow_vetservice_condition.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Derived Preference (Widow/Widower): Veteran's Service or Death Conditions
+title: "Derived Preference (Widow/Widower): Veteran's Service or Death Conditions"
 ---
 
 # Derived Preference (Widow/Widower): Veteran's Service or Death Conditions

--- a/advisor/ineligible_derived_mother_currentmarital.md
+++ b/advisor/ineligible_derived_mother_currentmarital.md
@@ -17,6 +17,6 @@ If you are currently married and your husband is not totally and permanently dis
 Therefore, under these OPM guidelines, you would not be eligible for derived preference as a mother.
 
 If you believe your situation is more complex or was misinterpreted:
-* `"[I want to re-evaluate my current marital/living status]"` -> `derived_mother_common_currentmarital.md`
-* `"[Return to Relationship Choice]"` -> `derived_intro.md`
-* `"[Return to Advisor Start]"` -> `start.md`
+* [I want to re-evaluate my current marital/living status](./derived_mother_common_currentmarital.md)
+* [Return to Relationship Choice](./derived_intro.md)
+* [Return to Advisor Start](./start.md)

--- a/advisor/ineligible_derived_mother_deceased_vetdeathcond.md
+++ b/advisor/ineligible_derived_mother_deceased_vetdeathcond.md
@@ -16,8 +16,8 @@ Furthermore, the **Note** in the Vet Guide clarifies an important restriction:
 This means if the veteran's service was entirely after July 1, 1955, and was not in a declared war or a campaign/expedition for which a medal was authorized, or if they did not die on active duty *during such specific qualifying service*, then derived preference for a mother is generally not granted.
 
 If you believe the veteran's service or death circumstances were misinterpreted:
-*   `"[I want to re-evaluate the veteran's service/death conditions]"` -> `derived_mother_deceased_vetdeathcond.md`
-*   `"[Return to Relationship Choice]"` -> `derived_intro.md`
-*   `"[Return to Advisor Start]"` -> `start.md`
+*   [I want to re-evaluate the veteran's service/death conditions](./derived_mother_deceased_vetdeathcond.md)
+*   [Return to Relationship Choice](./derived_intro.md)
+*   [Return to Advisor Start](./start.md)
 
 [Return to Advisor Start](./start.md)

--- a/advisor/ineligible_derived_mother_living_vetseparation.md
+++ b/advisor/ineligible_derived_mother_living_vetseparation.md
@@ -13,8 +13,8 @@ The OPM Vet Guide for HR Professionals, under "Mother of a disabled veteran," st
 If the veteran was not separated from active duty with an **honorable or general discharge**, then derived preference for a mother is not granted, even if the veteran is permanently and totally disabled from a service-connected injury or illness.
 
 If you believe the veteran's separation conditions were misinterpreted:
-*   `"[I want to re-evaluate the veteran's separation conditions]"` -> `derived_mother_living_vetseparation.md`
-*   `"[Return to Relationship Choice]"` -> `derived_intro.md`
-*   `"[Return to Advisor Start]"` -> `start.md`
+*   [I want to re-evaluate the veteran's separation conditions](./derived_mother_living_vetseparation.md)
+*   [Return to Relationship Choice](./derived_intro.md)
+*   [Return to Advisor Start](./start.md)
 
 [Return to Advisor Start](./start.md)

--- a/advisor/ineligible_ssp_familycriteria.md
+++ b/advisor/ineligible_ssp_familycriteria.md
@@ -8,15 +8,16 @@ title: Sole Survivor Preference - Ineligible: Family Criteria Not Met
 Based on your response, the family circumstances you described do not align with the specific criteria required for Sole Survivorship Preference (SSP).
 
 The OPM Vet Guide for HR Professionals, in the section "0-point Preference (SSP)," details these family-related conditions. Eligibility is for a veteran who is the only surviving child in a family where:
-*"...the father or mother or one or more siblings:
-* served in the armed forces, and
-* was killed, died as a result of wounds, accident, or disease, is in a captured or missing in action status, or is permanently 100 percent disabled or hospitalized on a continuing basis (and is not employed gainfully because of the disability or hospitalization), where
-* the death, status, or disability did not result from the intentional misconduct or willful neglect of the parent or sibling and was not incurred during a period of unauthorized absence."*
+> "...the father or mother or one or more siblings:
+> * served in the armed forces, and
+> * was killed, died as a result of wounds, accident, or disease, is in a captured or missing in action status, or is permanently 100 percent disabled or hospitalized on a continuing basis (and is not employed gainfully because of the disability or hospitalization), where
+> * the death, status, or disability did not result from the intentional misconduct or willful neglect of the parent or sibling and was not incurred during a period of unauthorized absence."
 
 If these specific conditions regarding a parent or sibling are not met, you are not eligible for Sole Survivorship Preference, even if you received a "sole survivorship discharge" for other reasons or meet the discharge date requirement.
 
 You may still be eligible for other types of veteran's preference (e.g., 5-point or 10-point disability preference) based on other aspects of your service.
 
-*   `"[I made a mistake, I want to re-evaluate the family criteria]"` -> `ownservice_ssp_familycriteria_info.md`
-*   `"[I want to explore other types of veteran's preference]"` -> `ownservice_nodisability_nossps_checkserviceperiod.md`
-*   `"[Return to Advisor Start]"` -> `start.md`
+*   [I made a mistake, I want to re-evaluate the family criteria](./ownservice_ssp_familycriteria_info.md)
+*   [I want to explore other types of veteran's preference](./ownservice_nodisability_nossps_checkserviceperiod.md)
+*   [**Return to Previous Page**](./ownservice_ssp_familycriteria_info.md)
+*   [**Return to Advisor Start**](./start.md)

--- a/advisor/ineligible_ssp_reason.md
+++ b/advisor/ineligible_ssp_reason.md
@@ -8,7 +8,7 @@ title: "Sole Survivor Preference - Ineligible: Reason for Discharge Not - Sole S
 Based on your response, the reason for your discharge from active duty was not a "sole survivorship discharge."
 
 The OPM Vet Guide for HR Professionals, in the section "0-point Preference (SSP)," explains that eligibility for this preference category is for:
-*"...veterans released or discharged from a period of active duty from the armed forces, after August 29, 2008, **by reason of a “sole survivorship discharge.”**"* (emphasis added)
+> "...veterans released or discharged from a period of active duty from the armed forces, after August 29, 2008, **by reason of a “sole survivorship discharge.”**" (emphasis added)
 
 If your discharge was for reasons other than a "sole survivorship discharge," you are not eligible for Sole Survivorship Preference (SSP), even if your discharge occurred after August 29, 2008.
 
@@ -16,4 +16,5 @@ You may still be eligible for other types of veteran's preference (e.g., 5-point
 
 *   [I made a mistake, I want to re-evaluate the reason for my discharge](./ownservice_ssp_checkdd214_reason.md)
 *   [I want to explore other types of veteran's preference](./ownservice_nodisability_nossps_checkserviceperiod.md)
-*   [Return to Advisor Start](./start.md)
+*   [**Return to Previous Page**](./ownservice_ssp_checkdd214_reason.md)
+*   [**Return to Advisor Start**](./start.md)

--- a/advisor/ineligible_tp_minduration.md
+++ b/advisor/ineligible_tp_minduration.md
@@ -8,13 +8,13 @@ layout: default
 Based on your responses, you may not meet the minimum active-duty service requirement for 5-point preference (TP), particularly if your service began after September 7, 1980 (or you began active duty on or after October 14, 1982, without previously completing 24 months of continuous active duty).
 
 The OPM Vet Guide for HR Professionals, in the "5-Point Preference (TP)" section, states:
-*"A campaign medal holder or Gulf War veteran who originally enlisted after September 7, 1980, (or began active duty on or after October 14, 1982, and has not previously completed 24 months of continuous active duty) must have served continuously for 24 months or the full period called or ordered to active duty."*
+> "A campaign medal holder or Gulf War veteran who originally enlisted after September 7, 1980, (or began active duty on or after October 14, 1982, and has not previously completed 24 months of continuous active duty) must have served continuously for 24 months or the full period called or ordered to active duty."
 
 It further notes:
-*"The 24-month service requirement does not apply to 10-point preference eligibles separated for disability incurred or aggravated in the line of duty, or to veterans separated for hardship or other reasons under 10 U.S.C. 1171 or 1173."* (This is also referenced in 38 U.S.C. 5303A(d)).
+> "The 24-month service requirement does not apply to 10-point preference eligibles separated for disability incurred or aggravated in the line of duty, or to veterans separated for hardship or other reasons under 10 U.S.C. 1171 or 1173." (This is also referenced in 38 U.S.C. 5303A(d)).
 
 If you do not meet this 24-month continuous service requirement (or did not complete the full period for which you were called/ordered to active duty) and the exceptions for disability or specific hardship separations do not apply to you, you may not be eligible for 5-point preference under this rule.
 
-*   `"[I want to review my service duration or check if exceptions apply]"` -> `ownservice_tp_24month_duration.md`
-*   `"[I want to review other service period choices for 5-point preference]"` -> `ownservice_nodisability_nossps_checkserviceperiod.md`
-*   `"[Return to Advisor Start]"` -> `start.md`
+*   [I want to review my service duration or check if exceptions apply](./ownservice_tp_24month_duration.md)
+*   [I want to review other service period choices for 5-point preference](./ownservice_nodisability_nossps_checkserviceperiod.md)
+*   [**Return to Advisor Start**](./start.md)

--- a/advisor/ineligible_vow_discharge_type.md
+++ b/advisor/ineligible_vow_discharge_type.md
@@ -8,12 +8,12 @@ title: "Own Service (VOW Act): Potentially Ineligible - Discharge Not Certified 
 Based on your response, your VOW (Veterans Opportunity to Work) Act certification does not indicate that your service member is expected to be discharged or released from active duty service under honorable conditions.
 
 The OPM Vet Guide for HR Professionals, in the section "A word about the VOW (Veterans Opportunity to Work) Act," describes the certification requirement:
-*"A “certification” is any written document from the armed forces that certifies the service member is expected to be discharged or released from active duty service in the armed forces **under honorable conditions** within 120 days after the certification is submitted by the applicant."* (emphasis added)
+> "A “certification” is any written document from the armed forces that certifies the service member is expected to be discharged or released from active duty service in the armed forces **under honorable conditions** within 120 days after the certification is submitted by the applicant." (emphasis added)
 
 It also notes a general requirement for preference in the "Types of Preference" section:
-*"To receive preference, a veteran must have been discharged or released from active duty in the Armed Forces under honorable conditions (i.e., with an honorable or general discharge)."*
+> "To receive preference, a veteran must have been discharged or released from active duty in the Armed Forces under honorable conditions (i.e., with an honorable or general discharge)."
 
 If your certification does not affirm an expectation of discharge under honorable conditions, agencies cannot grant tentative preference under the VOW Act. Final preference eligibility also depends on the actual character of service upon discharge.
 
-*   `"[I made a mistake, I want to re-check my VOW certification details regarding discharge conditions]"` -> `ownservice_vow_honorableconditions.md`
-*   `"[Return to Advisor Start]"` -> `start.md`
+*   [I made a mistake, I want to re-check my VOW certification details regarding discharge conditions](./ownservice_vow_honorableconditions.md)
+*   [**Return to Advisor Start**](./start.md)

--- a/advisor/ownservice_cp_details.md
+++ b/advisor/ownservice_cp_details.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Own Service: 10-Point Preference (CP) - 10-20% Disability
+title: "Own Service: 10-Point Preference (CP) - 10-20% Disability"
 ---
 
 # Own Service: 10-Point Preference (CP) - 10-20% Disability

--- a/advisor/ownservice_cps_details.md
+++ b/advisor/ownservice_cps_details.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Own Service: 10-Point Preference (CPS) - 30%+ Disability
+title: "Own Service: 10-Point Preference (CPS) - 30%+ Disability"
 ---
 
 # Own Service: 10-Point Preference (CPS) - 30%+ Disability

--- a/advisor/ownservice_disability_clarify_sf15.md
+++ b/advisor/ownservice_disability_clarify_sf15.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Own Service: Disability Preference - Clarification Needed
+title: "Own Service: Disability Preference - Clarification Needed"
 ---
 
 # Own Service: Disability Preference - Clarification Needed

--- a/advisor/ownservice_vow_retiredmajor_isdisabled.md
+++ b/advisor/ownservice_vow_retiredmajor_isdisabled.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Own Service (VOW Act): Retired Major/Lt. Cmdr+ - Check Disability
+title: "Own Service (VOW Act): Retired Major/Lt. Cmdr+ - Check Disability"
 ---
 
 # Own Service (VOW Act): Retired Major/Lt. Cmdr+ - Check Disability

--- a/advisor/ownservice_xp_generaldisability_details.md
+++ b/advisor/ownservice_xp_generaldisability_details.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Own Service: 10-Point Preference (XP) - General Disability
+title: "Own Service: 10-Point Preference (XP) - General Disability"
 ---
 
 # Own Service: 10-Point Preference (XP) - General Disability

--- a/advisor/ownservice_xp_purpleheart.md
+++ b/advisor/ownservice_xp_purpleheart.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Own Service: 10-Point Preference (XP) - Purple Heart
+title: "Own Service: 10-Point Preference (XP) - Purple Heart"
 ---
 
 # Own Service: 10-Point Preference (XP) - Purple Heart


### PR DESCRIPTION
Applied consistent formatting to several advisor markdown files to match the style of advisor/derived_mother_vetstatus.md.

Changes include:
- Standardized blockquotes to use '>' prefix.
- Updated link syntax to standard Markdown [Text](./path.md).
- Ensured "Return to Advisor Start" and "Return to Previous Page" links are bolded and correctly structured.
- Cleaned up formatting of bulleted list links.

Affected files:
- advisor/ineligible_vow_discharge_type.md
- advisor/ineligible_tp_minduration.md
- advisor/ineligible_ssp_reason.md
- advisor/ineligible_ssp_familycriteria.md