### PR TITLE
feat: Make project name in header a link to homepage

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,7 @@
     <a id="skip-to-content" href="#content">Skip to the content.</a>
 
     <header class="page-header" role="banner">
-      <h1 class="project-name">{{ page.title | default: site.title | default: site.github.repository_name }}</h1>
+      <a href="/" style="text-decoration: none; color: inherit;"><h1 class="project-name">{{ page.title | default: site.title | default: site.github.repository_name }}</h1></a>
       <h2 class="project-tagline">{{ page.description | default: site.description | default: site.github.project_tagline }}</h2>
       {% if site.github.is_project_page %}
         <a href="{{ site.github.repository_url }}" class="btn">View on GitHub</a>


### PR DESCRIPTION
This change modifies the default layout to wrap the project name in the header with an anchor tag linking to the root directory ('/'). This provides a consistent way for you to navigate back to the homepage from any page on the site that uses the default layout.

Inline styling was added to ensure the link inherits the parent text color and has no text decoration, maintaining the visual consistency of the header.